### PR TITLE
[BASIC] Move token offset for BASIC functions to $D0 to increase available unallocated statement tokens

### DIFF
--- a/basic/code10.s
+++ b/basic/code10.s
@@ -214,7 +214,7 @@ isfun
 	bne :+
 snerr9:	jmp snerr
 :	sec
-	sbc #$c0
+	sbc #$d0
 	cmp #num_esc_functions
 	bcs snerr9
 

--- a/basic/code2.s
+++ b/basic/code2.s
@@ -92,8 +92,8 @@ rescon2	lda bufofs,x
 	lda count
 	cmp #num_esc_statements	; check if statement or function
 	bcc :+
-	adc #($c0 - num_esc_statements - 1) ; an extended function (index $C0-$FF)
-:	ora #128 ; an extended statement (index $80-BF)
+	adc #($d0 - num_esc_statements - 1) ; an extended function (index $D0-$FF)
+:	ora #128 ; an extended statement (index $80-CF)
 	ldy bufptr
 	inx
 	iny

--- a/basic/code3.s
+++ b/basic/code3.s
@@ -73,9 +73,9 @@ nqplop	bpl ploop
 	bne nesctk
 	iny
 	lda (lowtr),y
-	cmp #$c0 ; check if statement or function
+	cmp #$d0 ; check if statement or function
 	bcc :+
-	sbc #($c0 - num_esc_statements - 1) ; a function
+	sbc #($d0 - num_esc_statements - 1) ; a function
 	bra :++
 :	sec
 	sbc #127 ; a statement


### PR DESCRIPTION
The X16 additional BASIC statements start at token offset $80, and until https://github.com/X16Community/x16-rom/pull/6 which moved functions to start at offset $C0, the functions immediately followed statements.  This broke PRG compatibility of saved BASIC programs between emulator versions any time statements were added as it shifted the tokens of functions upwards.  This was addressed by https://github.com/X16Community/x16-rom/pull/6  

As we've added more BASIC statements, I fear the number of unallocated statement tokens is pretty small by comparison to the available function tokens.

Moving the start of functions from $C0 to $D0 seems prudent at this stage to ensure PRG compatibility for BASIC programs from R42 onward while giving us plenty of headroom for additional BASIC statements and functions.