### PR TITLE
[BASIC] add tertiary reserved words table

### DIFF
--- a/basic/code2.s
+++ b/basic/code2.s
@@ -89,7 +89,7 @@ rescon2	lda bufofs,x
 	cmp #128
 	bne nthis2
 
-	lda count
+resfnd	lda count
 	cmp #num_esc_statements	; check if statement or function
 	bcc :+
 	adc #($d0 - num_esc_statements - 1) ; an extended function (index $D0-$FF)
@@ -113,6 +113,28 @@ nthis12	iny
 	bpl nthis12
 	lda reslst2,y
 	bne rescon2
+
+;***** Extended statements, part deux (don't reset count)
+	ldy #$ff
+	dex
+reser3	iny
+	inx
+rescon3	lda bufofs,x
+	sec
+	sbc reslst3,y
+	beq reser3
+	cmp #128
+	bne nthis3
+	bra resfnd
+
+nthis3	ldx txtptr
+	inc count
+nthis13	iny
+	lda reslst3-1,y
+	bpl nthis13
+	lda reslst3,y
+	bne rescon3
+
 	lda bufofs,x
 	bmi crdone
 	ldy bufptr

--- a/basic/code2.s
+++ b/basic/code2.s
@@ -124,8 +124,7 @@ rescon3	lda bufofs,x
 	sbc reslst3,y
 	beq reser3
 	cmp #128
-	bne nthis3
-	bra resfnd
+	beq resfnd
 
 nthis3	ldx txtptr
 	inc count

--- a/basic/code3.s
+++ b/basic/code3.s
@@ -86,10 +86,25 @@ resrch2	dex
 	beq prit32
 rescr11	iny
 	lda reslst2,y
+	beq resdt3
 	bpl rescr11
 	bmi resrch2
+resdt3	ldy #255
+	inx
+resrch3	dex
+	beq prit33
+rescr12	iny
+	lda reslst3,y
+	bpl rescr12
+	bmi resrch3
+prit33	iny
+	lda reslst3,y
+	bmi prit4
+	jsr outdo
+	bne prit33
 prit32	iny
 	lda reslst2,y
+	beq resdt3
 	bmi prit4
 	jsr outdo
 	bne prit32
@@ -108,8 +123,9 @@ rescr1	iny
 	bmi resrch
 prit3	iny
 	lda reslst,y
-	bmi prit4
-	jsr outdo
+	bpl :+
+	jmp prit4
+:	jsr outdo
 	bne prit3
 for	lda #128
 	sta subflg

--- a/basic/token2.s
+++ b/basic/token2.s
@@ -100,7 +100,14 @@ reslst2	.byt "MO", 'N' + $80
 	.byt "PSGFRE", 'Q' + $80
 	.byt "PSGPA", 'N' + $80
 	.byt "PSGPLA", 'Y' + $80
+	.byt 0 ; keep this last
+	; The division between reslst2 and reslst3 is arbitrary, but the order
+	; must be maintained. Parser will check all of reslst2 and then
+	; continue onward with checking entries in reslst3.
+reslst3: 
 	.byt "PSGCHOR", 'D' + $80
+	; add new statements before this line
+	; functions start here
 	.byt "VPEE", 'K' + $80
 	.byt "M", 'X' + $80
 	.byt "M", 'Y' + $80
@@ -108,7 +115,10 @@ reslst2	.byt "MO", 'N' + $80
 	.byt "JO", 'Y' + $80
 	.byt "HEX", $a4
 	.byt "BIN", $a4
+	; add new functions before this line
 	.byt 0
+
+.assert reslst3 - reslst2 < 256, error, "<--- See line number. Too many bytes in reslst2. Keep the ordering of the statements but move one of the declarations from the end of reslst2 to the beginning of reslst3.  Keep the .byt 0 as the final entry of reslst2."
 ;**************************************
 
 err01	.byt "TOO MANY FILE",$d3

--- a/basic/token2.s
+++ b/basic/token2.s
@@ -104,9 +104,10 @@ reslst2	.byt "MO", 'N' + $80
 	; The division between reslst2 and reslst3 is arbitrary, but the order
 	; must be maintained. Parser will check all of reslst2 and then
 	; continue onward with checking entries in reslst3.
-reslst3: 
-	.byt "PSGCHOR", 'D' + $80
+reslst3	.byt "PSGCHOR", 'D' + $80
+
 	; add new statements before this line
+
 	; functions start here
 	.byt "VPEE", 'K' + $80
 	.byt "M", 'X' + $80
@@ -115,6 +116,7 @@ reslst3:
 	.byt "JO", 'Y' + $80
 	.byt "HEX", $a4
 	.byt "BIN", $a4
+
 	; add new functions before this line
 	.byt 0
 


### PR DESCRIPTION
`reslst2` is a table of the new X16 reserved words for the command parser.  We were at the cusp of the 256 byte index offset limit for this table before a contributor attempted to add a single BASIC command which ended up deadlocking the BASIC interpreter as the final "0" could never be reached in an 8-bit index register.

The changes add an additional reserved words table `reslst3` and additional code to check it.  It also adds a linker `.assert` to ensure the former table does not ever grow beyond 255 bytes