### PR TITLE
[KERNAL] Add RAM NMI trampoline, add NMI vectors to every bank

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,8 @@ ifneq ($(MACHINE),c64)
 endif
 
 KEYMAP_SOURCES = \
-	keymap/keymap.s
+	keymap/keymap.s \
+	keymap/vectors.s
 
 DOS_SOURCES = \
 	dos/fat32/fat32.s \
@@ -270,7 +271,8 @@ MONITOR_SOURCES= \
 
 CHARSET_SOURCES= \
 	charset/petscii.s \
-	charset/iso-8859-15.s
+	charset/iso-8859-15.s \
+	charset/vectors.s
 
 GRAPH_SOURCES= \
 	graphics/jmptbl.s \

--- a/cfg/charset-x16.cfgtpl
+++ b/cfg/charset-x16.cfgtpl
@@ -1,7 +1,7 @@
 MEMORY {
 	#include "x16.cfginc"
 
-	BANK6:    start = $C000, size = $4000, fill=yes, fillval=$AA;
+	BANK6:    start = $C000, size = $3FFA, fill=yes, fillval=$AA;
 	VECTORS:  start = $FFFA, size = $0006, fill=yes, fillval=$AA;
 }
 

--- a/cfg/charset-x16.cfgtpl
+++ b/cfg/charset-x16.cfgtpl
@@ -2,9 +2,11 @@ MEMORY {
 	#include "x16.cfginc"
 
 	BANK6:    start = $C000, size = $4000, fill=yes, fillval=$AA;
+	VECTORS:  start = $FFFA, size = $0006, fill=yes, fillval=$AA;
 }
 
 SEGMENTS {
 	CHARSET:    load = BANK6,    type = ro;
 	CHARISO:    load = BANK6,    type = ro;
+	VECTORS:    load = VECTORS,  type = ro;
 }

--- a/cfg/dos-x16.cfgtpl
+++ b/cfg/dos-x16.cfgtpl
@@ -1,8 +1,8 @@
 MEMORY {
 	#include "x16.cfginc"
 
-	DOS:      start = $C000, size = $3FFE, fill=yes, fillval=$AA;
-	IRQB:     start = $FFFE, size = $0002, fill=yes, fillval=$AA;
+	DOS:      start = $C000, size = $3FFA, fill=yes, fillval=$AA;
+	IRQB:     start = $FFFA, size = $0006, fill=yes, fillval=$AA;
 }
 
 SEGMENTS {

--- a/cfg/keymap-x16.cfgtpl
+++ b/cfg/keymap-x16.cfgtpl
@@ -1,7 +1,7 @@
 MEMORY {
 	#include "x16.cfginc"
 
-	KEYMAPS:  start = $C000, size = $4000, fill=yes, fillval=$AA;
+	KEYMAPS:  start = $C000, size = $3FFA, fill=yes, fillval=$AA;
 	VECTORS:  start = $FFFA, size = $0006, fill=yes, fillval=$AA;
 }
 

--- a/cfg/keymap-x16.cfgtpl
+++ b/cfg/keymap-x16.cfgtpl
@@ -2,9 +2,11 @@ MEMORY {
 	#include "x16.cfginc"
 
 	KEYMAPS:  start = $C000, size = $4000, fill=yes, fillval=$AA;
+	VECTORS:  start = $FFFA, size = $0006, fill=yes, fillval=$AA;
 }
 
 SEGMENTS {
 	KBDMETA:    load = KEYMAPS,  type = ro;
 	KBDTABLES:  load = KEYMAPS,  type = ro;
+	VECTORS:    load = VECTORS,  type = ro;
 }

--- a/cfg/x16.cfginc
+++ b/cfg/x16.cfginc
@@ -33,7 +33,7 @@ KVECTORS: start = $0314, size = $0020; # KERNAL vectors
 
 /* $0334-$03FF: variables and RAM code (not available for *legacy* GEOS apps) */
 KVAR2:    start = $0334, size = $0057; # KERNAL: screen editor table
-KERNRAM2: start = $038B, size = $003F; # KERNAL: banked IRQ, fetch, stash
+KERNRAM2: start = $038B, size = $003F; # KERNAL: banked IRQ/NMI, fetch, stash
 FPVARS:   start = $03CA, size = $0009; # MATH
 BVARS:    start = $03D3, size = $002D; # BASIC
 

--- a/charset/vectors.s
+++ b/charset/vectors.s
@@ -1,6 +1,6 @@
 .include "banks.inc"
 
 .segment "VECTORS"
-    .word banked_nmi
-    .word $ffff
-    .word banked_irq
+	.word banked_nmi
+	.word $ffff
+	.word banked_irq

--- a/charset/vectors.s
+++ b/charset/vectors.s
@@ -1,0 +1,6 @@
+.include "banks.inc"
+
+.segment "VECTORS"
+.word banked_nmi
+.word $ffff
+.word banked_irq

--- a/charset/vectors.s
+++ b/charset/vectors.s
@@ -1,6 +1,6 @@
 .include "banks.inc"
 
 .segment "VECTORS"
-.word banked_nmi
-.word $ffff
-.word banked_irq
+    .word banked_nmi
+    .word $ffff
+    .word banked_irq

--- a/codex/inc/x16_kernal.inc
+++ b/codex/inc/x16_kernal.inc
@@ -111,7 +111,7 @@
 	;; RAM variabls, should extract from a SYM file produced by the kernal
 	BRK_VECTOR    = $0316
 	FETCH_VECTOR  = $03AF
-	STASH_VECTOR  = $03B7
+	STASH_VECTOR  = $03B2
 
 	;;
 	

--- a/codex/src/kernsup_cx.s
+++ b/codex/src/kernsup_cx.s
@@ -36,6 +36,6 @@ mjsrfar:
 
 	.byte 0, 0, 0, 0 ; signature
 
-	.word $ffff ; nmi
+	.word banked_nmi ; nmi
 	.word $ffff ; reset
 	.word banked_irq

--- a/dos/main.s
+++ b/dos/main.s
@@ -549,5 +549,7 @@ dos_macptr:
 
 ;---------------------------------------------------------------
 .segment "IRQB"
+	.word banked_nmi
+	.word $ffff
 	.word banked_irq
 

--- a/graphics/jmptbl.s
+++ b/graphics/jmptbl.s
@@ -74,4 +74,4 @@ jmp (I_FB_move_pixels)          ;C060
 
 .include "banks.inc"
 .segment "VECTORS" 
- .byt $ff, $ff, $ff, $ff, <banked_irq, >banked_irq
+ .byt <banked_nmi, >banked_nmi, $ff, $ff, <banked_irq, >banked_irq

--- a/inc/banks.inc
+++ b/inc/banks.inc
@@ -20,7 +20,8 @@ jsrfar3    = $02c4 ; jsrfar: RAM part
 jmpfr      = $02df ; jsrfar: core jmp instruction
 imparm     = $82   ; jsrfar: temporary byte
 stavec     = $03b2 ; stash: argument
-banked_irq = $038b ; irq handler: RAM part
+banked_irq = $038b ; irq handler: RAM part         this value MUST NEVER CHANGE starting from R42
+banked_nmi = $03b7 ; nmi handler: RAM trampoline   this value MUST NEVER CHANGE starting from R42
 .elseif .defined(MACHINE_C64)
 status     = $029F
 ;fa         = $029F

--- a/kernal/cbm/nmi.s
+++ b/kernal/cbm/nmi.s
@@ -6,21 +6,38 @@
 
 .feature labels_without_colons
 
+rom_bank = 1
 monitor = $fecc
 .import enter_basic, cint, ioinit, restor, nminv
+.import call_audio_init
 
 .export nmi, nnmi, timb
 
 	.segment "NMI"
 
-nmi	jmp (nminv)
-nnmi
+; sets up the stack just like the RAM trampoline does
+nmi	pha
+	lda rom_bank
+	pha
+	jmp (nminv)
+
+; warm reset, ctrl+alt+restore, default value for (nminv)
+nnmi jsr ioinit           ;go initilize i/o devices
+	jsr restor           ;go set up os vectors
+;
+	jsr cint             ;go initilize screen
+	jsr call_audio_init  ;initialize audio API and HW.
+
+	clc
+	jmp enter_basic
+
 ;
 ; timb - where system goes on a brk instruction
 ;
 timb	jsr restor      ;restore system indirects
 	jsr ioinit      ;restore i/o for basic
 	jsr cint        ;restore screen for basic
+	jsr call_audio_init  ;initialize audio API and HW.
 	clc
 	jmp monitor
 

--- a/kernal/cbm/nmi.s
+++ b/kernal/cbm/nmi.s
@@ -22,7 +22,7 @@ nmi	pha
 	jmp (nminv)
 
 ; warm reset, ctrl+alt+restore, default value for (nminv)
-nnmi jsr ioinit           ;go initilize i/o devices
+nnmi	jsr ioinit           ;go initilize i/o devices
 	jsr restor           ;go set up os vectors
 ;
 	jsr cint             ;go initilize screen

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -11,6 +11,7 @@
 .import __KVARSB0_LOAD__, __KVARSB0_RUN__, __KVARSB0_SIZE__
 .import memtop
 .import membot
+.import nminv
 
 .import ieeeswitch_init
 
@@ -268,6 +269,15 @@ __stavec	=*+1
 	plx
 	stx ram_bank
 	rts
+
+.assert * = banked_nmi, error, "banked_nmi must be at specific address"
+__banked_nmi:
+	pha
+	lda rom_bank
+	pha
+	stz rom_bank
+	jmp (nminv)
+
 
 .segment "MEMDRV"
 

--- a/kernsup/kernsup_audio.s
+++ b/kernsup/kernsup_audio.s
@@ -36,6 +36,6 @@ ajsrfar:
 
     .byte 0, 0, 0, 0 ; signature
 
-    .word $ffff ; nmi
+    .word banked_nmi ; nmi
     .word $ffff ; reset
     .word banked_irq

--- a/kernsup/kernsup_audio.s
+++ b/kernsup/kernsup_audio.s
@@ -1,7 +1,5 @@
 .include "banks.inc"
 
-.import bjsrfar
-
 .macro bridge symbol
 	.local address
 	.segment "KSUP_VEC10"
@@ -22,8 +20,8 @@ symbol:
 
 ; Audio bank's entry into jsrfar
 .setcpu "65c02"
-    ram_bank = 0
-    rom_bank = 1
+	ram_bank = 0
+	rom_bank = 1
 .export ajsrfar
 ajsrfar:
 .include "jsrfar.inc"
@@ -31,11 +29,11 @@ ajsrfar:
 
 .segment "KSUP_VEC10"
 
-    xjsrfar = ajsrfar
+	xjsrfar = ajsrfar
 .include "kernsup.inc"
 
-    .byte 0, 0, 0, 0 ; signature
+	.byte 0, 0, 0, 0 ; signature
 
-    .word banked_nmi ; nmi
-    .word $ffff ; reset
-    .word banked_irq
+	.word banked_nmi ; nmi
+	.word $ffff ; reset
+	.word banked_irq

--- a/kernsup/kernsup_basic.s
+++ b/kernsup/kernsup_basic.s
@@ -23,6 +23,6 @@ symbol:
 
 	.byte 0, 0, 0, 0 ; signature
 
-	.word $ffff ; nmi
+	.word banked_nmi ; nmi
 	.word $ffff ; reset
 	.word banked_irq

--- a/kernsup/kernsup_monitor.s
+++ b/kernsup/kernsup_monitor.s
@@ -36,6 +36,6 @@ mjsrfar:
 
 	.byte 0, 0, 0, 0 ; signature
 
-	.word $ffff ; nmi
+	.word banked_nmi ; nmi
 	.word $ffff ; reset
 	.word banked_irq

--- a/keymap/vectors.s
+++ b/keymap/vectors.s
@@ -1,6 +1,6 @@
 .include "banks.inc"
 
 .segment "VECTORS"
-    .word banked_nmi
-    .word $ffff
-    .word banked_irq
+	.word banked_nmi
+	.word $ffff
+	.word banked_irq

--- a/keymap/vectors.s
+++ b/keymap/vectors.s
@@ -1,0 +1,6 @@
+.include "banks.inc"
+
+.segment "VECTORS"
+.word banked_nmi
+.word $ffff
+.word banked_irq

--- a/keymap/vectors.s
+++ b/keymap/vectors.s
@@ -1,6 +1,6 @@
 .include "banks.inc"
 
 .segment "VECTORS"
-.word banked_nmi
-.word $ffff
-.word banked_irq
+    .word banked_nmi
+    .word $ffff
+    .word banked_irq


### PR DESCRIPTION
Prior to this commit, not every ROM bank had 6502 vectors installed.  This PR includes IRQ and NMI support in all banks.

In addition, David Murray has expressed a desire for NMI behavior to match the C64's STOP+RESTORE behavior.  Barring repeating the trampoline verbatim in every bank at the same addresses, doing this reliably requires a RAM-based trampoline.  There were 9-free bytes at the end of `KERNRAM2` and this new trampoline takes all 9 of them.

The trampoline, to allow for custom NMI handlers that return to the caller, preserve the A register and the previous ROM bank on the stack before setting the ROM bank to 0 and jumping indirect through (nminv).

In the default case, this does a warm reset by re-initializing I/O devices, restoring the KERNAL vectors, and eventually jumping into the `panic` label in BASIC which clears the stack and returns the user to the `READY.` prompt without erasing the BASIC program.