### PR TITLE
[KERNAL] Handle line wrap correctly in 20 column modes

### DIFF
--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -20,7 +20,7 @@
 ;screen editor constants
 ;
 maxchr=80
-nwrap=2 ;max number of physical lines per logical line
+nwrap=4 ;max number of physical lines per logical line
 
 .export plot   ; set cursor position
 .export scrorg ; return screen size
@@ -230,7 +230,7 @@ stok	jsr screen_set_position
 ;
 	lda llen
 .ifp02
-	clc
+	clc ; XXX is this correct?? (not reached because X16 is 65C02)
 	sbc #1
 .else
 	dec
@@ -903,7 +903,7 @@ back	dec tblx
 chkdwn	ldx #nwrap
 	lda llen
 .ifp02
-	clc
+	clc ; XXX is this correct?? (not reached because X16 is 65C02)
 	sbc #1
 .else
 	dec
@@ -924,18 +924,18 @@ dnline	ldx tblx
 dwnbye	rts
 
 chkcol
-        cmp #1          ;check ctrl-a for invert.
-        bne ntinv
-        lda color       ;get current text color.
-        asl a           ;swap msn/lsn.
-        adc #$80
-        rol a
-        asl a
-        adc #$80
-        rol a
-        sta color       ;stash back.
-        lda #1          ;restore .a
-        rts
+	cmp #1          ;check ctrl-a for invert.
+	bne ntinv
+	lda color       ;get current text color.
+	asl a           ;swap msn/lsn.  ; c 11010000 -> 1 10100000
+	adc #$80        ; example ->    ; 1 10100000 -> 1 00100001
+	rol a           ;               ; 1 00100001 -> 0 01000011
+	asl a           ; clever        ; c 01000011 -> 0 10000110
+	adc #$80        ;  approach!    ; 0 10000110 -> 1 00000110
+	rol a                           ; 1 00000110 -> 0 00001101
+	sta color       ;stash back.
+	lda #1          ;restore .a
+	rts
 ntinv
 	ldx #15         ;there's 15 colors
 chk1a	cmp coltab,x

--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -230,7 +230,7 @@ stok	jsr screen_set_position
 ;
 	lda llen
 .ifp02
-	clc ; XXX is this correct?? (not reached because X16 is 65C02)
+	sec
 	sbc #1
 .else
 	dec
@@ -905,7 +905,7 @@ back	dec tblx
 chkdwn	ldx #nwrap
 	lda llen
 .ifp02
-	clc ; XXX is this correct?? (not reached because X16 is 65C02)
+	sec
 	sbc #1
 .else
 	dec

--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -891,8 +891,10 @@ chklup	cmp pntr
 	beq back
 	clc
 	adc llen
+	bcs :+ ; abort check if column overflowed
 	dex
 	bne chklup
+:
 	rts
 ;
 back	dec tblx
@@ -912,8 +914,10 @@ dwnchk	cmp pntr
 	beq dnline
 	clc
 	adc llen
+	bcs :+ ; abort check if column overflowed
 	dex
 	bne dwnchk
+:
 	rts
 ;
 dnline	ldx tblx

--- a/kernal/drivers/x16/screen.s
+++ b/kernal/drivers/x16/screen.s
@@ -310,11 +310,15 @@ screen_set_position:
 ;   Out:  .a       PETSCII/ISO
 ;---------------------------------------------------------------
 screen_get_color:
+	phx ; preserve X (restored after branch)
+	ldx #0
 	tya
+:
 	cmp llen
 	bcc :+
-	sec
-	sbc llen
+	sbc llen ; C=1
+	inx
+	bra :-
 :
 	sec
 	rol
@@ -328,22 +332,27 @@ screen_get_color:
 ;   Out:  .a       PETSCII/ISO
 ;---------------------------------------------------------------
 screen_get_char:
+	phx ; preserve X
+	ldx #0
 	tya
+ldapnt0:
 	cmp llen
 	bcc ldapnt1
-	sec
-	sbc llen
-	asl
-	sta VERA_ADDR_L
-	lda pnt+1
-	adc #1 ; C=0
-	bne ldapnt3
+	sbc llen ; C=1
+	inx
+	bra ldapnt0
 ldapnt1:
 	asl
 ldapnt2:
 	sta VERA_ADDR_L
 	lda pnt+1
+:
+	dex
+	bmi ldapnt3
+	inc
+	bra :-
 ldapnt3:
+	plx ; restore X
 	clc
 	adc #<(>screen_addr)
 	sta VERA_ADDR_M
@@ -363,11 +372,15 @@ ldapnt3:
 ;---------------------------------------------------------------
 screen_set_color:
 	pha
+	phx ; preserve X (restored after branch)
+	ldx #0
 	tya
+:
 	cmp llen
 	bcc :+
-	sec
-	sbc llen
+	sbc llen ; C=1
+	inx
+	bra :-
 :
 	sec
 	rol
@@ -383,22 +396,27 @@ screen_set_color:
 ;---------------------------------------------------------------
 screen_set_char:
 	pha
+	phx ; preserve X
+	ldx #0
 	tya
+stapnt0:
 	cmp llen
 	bcc stapnt1
-	sec
-	sbc llen
-	asl
-	sta VERA_ADDR_L
-	lda pnt+1
-	adc #1 ; C=0
-	bne stapnt3
+	sbc llen ; C=1
+	inx
+	bra stapnt0
 stapnt1:
 	asl
 stapnt2:
 	sta VERA_ADDR_L
 	lda pnt+1
+:
+	dex
+	bmi stapnt3
+	inc
+	bra :-
 stapnt3:
+	plx ; restore X
 	clc
 	adc #<(>screen_addr)
 	sta VERA_ADDR_M


### PR DESCRIPTION
This PR fixes bugs related to 20 column modes in two places
1) screen.s: for putting or fetching characters and/or colors from VERA memory, the logical column can be up to 80 characters.  The previous code calculated addresses correctly for 40 and 80 column modes by subtracting the screen width from the virtual column to find the physical column (and added a row) if we were in 40 column mode and we were at column 40 or above. For 20 column modes, we need a more complex process to calculate the VERA address, as this virtual column can live on any one of four rows if we allow for the current limit of 80 virtual columns.
2) editor.s: Now that a virtual line can span up to 4 rows (instead of 2), the check for EOL can overflow in 80 column mode and spuriously test true for non-EOL cursor positions. Even though we don't need to check 4 rows in 40 or 80 column mode, the check always loops the same number of times. If we overflow, the condition for EOL must be false, so we can safely abort the check upon overflow.

Closes https://github.com/commanderx16/x16-rom/issues/346
Closes https://github.com/commanderx16/x16-rom/issues/319