### PR TITLE
[KERNAL] Abort VERIFY operation at the first error.

### DIFF
--- a/kernal/cbm/channel/load.s
+++ b/kernal/cbm/channel/load.s
@@ -211,7 +211,7 @@ ld47	cmp (eal),y     ;verify it
 	beq ld60        ;o.k....
 	lda #16         ;no good...verify error (sperr)
 	jsr udst        ;update status
-	bra ld60
+	bra ld70
 ;
 ld50	ldy #0
 	sta (eal),y


### PR DESCRIPTION
Unlike the upstream C64 source (verified by its disassembly), both variants of ACPTR on the X16 (both serial and VERA/sd card) zero the status byte unconditionally at the beginning of the function.  This breaks the expectation of the original VERIFY behavior which used the status byte to accumulate errors.

The easiest workaround seems to be to abort the verify at the first difference and report failure, otherwise the verify operation would only return failure if the final byte of the file and the final byte in memory had a mismatch.

Closes #15 