### PR TITLE
[KERNAL] support nvram storage of screen mode configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
           sudo apt-get install -y make build-essential
           git clone https://github.com/cc65/cc65.git
           cd cc65
+          git checkout c097401f8bd907b3994b68e7e8b47d50b4a1864c
           make -j4
           sudo make install
       - name: Build ROM

--- a/basic/init.s
+++ b/basic/init.s
@@ -147,6 +147,7 @@ initm3	jsr linprt
 	lda #<words
 	ldy #>words
 	jsr strout
+	jsr screen_default_color_from_nvram
 	jmp scrtch
 
 bvtrs	.word nerror,nmain,ncrnch,nqplop,ngone,neval

--- a/basic/init.s
+++ b/basic/init.s
@@ -168,6 +168,7 @@ fremes
 	.byt $9a, $12, $b4, $df, $92, "   ", $12, $a9, $a7, $92
 	.byt 5, " **** COMMANDER X16 BASIC V2 ****"
 	.byt $0d
+	.byt $13, $11, $11
 	; line 2
 	.byt $9f, $12, $b5, " ", $df, $92, " ", $12, $a9, " ", $b6
 	.byt $0d

--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -265,25 +265,19 @@ loop3
 	and #(255-MODIFIER_4080)
 	sta shflag
 	
-;	sec             ;Get current screen mode
-;	jsr screen_mode
-;
-;	eor #SCREEN_MODE_4030
-;	clc
-;:	jsr screen_mode ;Set new screen mode, will clear screen
 	and #MODIFIER_SHIFT
 	bne scrpnc
 	jsr screen_toggle_default_nvram
 	bra doredy
 scrpnc
-	; screen panic, toggle between VGA/composite mode
+	; screen panic, cycle through VGA/composite/RGB modes
 	stz VERA_CTRL
 	lda VERA_DC_VIDEO
-	and #3
-	dec
-	and #1
-	eor #1
 	inc
+	and #3
+	bne :+
+	inc
+:
 	sta tmp2
 	lda VERA_DC_VIDEO
 	and #$70

--- a/kernal/cbm/init.s
+++ b/kernal/cbm/init.s
@@ -6,7 +6,7 @@
 
 .feature labels_without_colons
 
-.import cint, ramtas, ioinit, enter_basic, restor, vera_wait_ready, call_audio_init, boot_cartridge
+.import cint, ramtas, ioinit, enter_basic, restor, vera_wait_ready, call_audio_init, boot_cartridge, screen_set_defaults_from_nvram
 
 .export start
 
@@ -23,6 +23,7 @@ start	ldx #$ff
 ;
 	jsr cint             ;go initilize screen
 	jsr call_audio_init  ;initialize audio API and HW.
+	jsr screen_set_defaults_from_nvram
 	jsr boot_cartridge   ;if a cart ROM in bank 32, jump into its start location
 	cli                  ;interrupts okay now
 

--- a/kernal/drivers/x16/rtc.s
+++ b/kernal/drivers/x16/rtc.s
@@ -16,6 +16,7 @@
 rtc_address            = $6f
 
 nvram_base             = $20
+nvram_size             = $40
 screen_mode_cksum_addr = nvram_base + $15
 
 ;---------------------------------------------------------------
@@ -180,10 +181,15 @@ rtc_set_nvram:
 	sec
 rtc_nvram:
 	php
+	cpy #(nvram_base + nvram_size)
+	bcc :+
+	plp
+	sec
+	bra @exit	
+:
 	pha
 
 	tya
-	and #$3f
 	clc
 	adc #nvram_base
 	tay

--- a/kernal/drivers/x16/screen.s
+++ b/kernal/drivers/x16/screen.s
@@ -714,6 +714,9 @@ screen_set_mode_from_nvram:
 	sta VERA_DC_VIDEO
 	and #3
 	beq @panic ; load defaults if DC_VIDEO specifies no outputs
+	lda VERA_DC_VIDEO
+	and #$20
+	beq @panic ; load defaults if DC_VIDEO does not configure layer 1
 	jsr @incandfetch
 	beq @panic ; load defaults if DC_HSCALE is 0
 	sta VERA_DC_HSCALE

--- a/kernal/drivers/x16/screen.s
+++ b/kernal/drivers/x16/screen.s
@@ -22,6 +22,8 @@
 .export screen_clear_line
 .export screen_save_state
 .export screen_restore_state
+.export screen_set_defaults_from_nvram
+.export screen_toggle_default_nvram
 
 ; kernal var
 .importzp sal, sah ; reused temps from load/save
@@ -37,6 +39,11 @@
 .import fetch, fetvec; [routines]
 
 .import GRAPH_init
+
+; RTC
+.import rtc_set_nvram
+.import rtc_get_nvram
+.import rtc_check_nvram_checksum
 
 .segment "KVAR"
 
@@ -665,3 +672,138 @@ inicpy:
 	stz data
 	stz tmp2
 	rts
+
+screen_toggle_default_nvram:
+	ldy #0
+	jsr rtc_get_nvram
+	and #1
+	eor #1
+	ldy #0
+	jsr rtc_set_nvram
+
+screen_set_defaults_from_nvram:
+	ldy #0
+	jsr rtc_get_nvram
+
+	
+screen_set_mode_from_nvram:
+	and #1
+	pha
+	; first check the nvram checksum
+	jsr rtc_check_nvram_checksum
+	beq :+
+	pla
+	jmp screen_set_default_nvram
+:
+	pla
+	beq :+
+	clc
+	adc #9
+:
+	inc
+	tay
+
+	phy
+	jsr rtc_get_nvram
+	clc
+	jsr screen_mode
+	ply
+
+	stz VERA_CTRL
+	jsr @incandfetch
+	sta VERA_DC_VIDEO
+	and #3
+	beq @panic ; load defaults if DC_VIDEO specifies no outputs
+	jsr @incandfetch
+	beq @panic ; load defaults if DC_HSCALE is 0
+	sta VERA_DC_HSCALE
+	jsr @incandfetch
+	beq @panic ; load defaults if DC_VSCALE is 0
+	sta VERA_DC_VSCALE
+	jsr @incandfetch
+	sta VERA_DC_BORDER
+	lda #2
+	sta VERA_CTRL
+	jsr @incandfetch
+	sta VERA_DC_HSTART
+	jsr @incandfetch
+	beq @panic ; load defaults if DC_HSTOP is 0
+	sta VERA_DC_HSTOP
+	jsr @incandfetch
+	sta VERA_DC_VSTART
+	jsr @incandfetch
+	beq @panic ; load defaults if DC_VSTOP is 0
+	sta VERA_DC_VSTOP
+	stz VERA_CTRL
+	jsr @incandfetch
+	sta color
+
+	; swap nibbles
+	asl
+	adc #$80
+	rol
+	asl
+	adc #$80
+	rol
+	cmp color
+	beq @panic ; load defaults if default text fg/bg are equal
+
+	clc
+	rts
+@panic:
+	jmp screen_set_default_nvram
+@incandfetch:
+	iny
+	phy
+	jsr rtc_get_nvram
+	ply
+	ora #0
+	rts
+
+screen_set_default_nvram:
+	ldy #0
+@loop:
+	phy
+	lda @defaults, y
+	jsr rtc_set_nvram
+	ply
+	bcs @set_default
+	iny
+	cpy #$15
+	bcc @loop
+@set_default:
+	lda @defaults+1
+	clc
+	jsr screen_mode
+
+	; Just in case the RTC is failing to hold values properly at all,
+	; we apply the the defaults of the first profile rather than jumping
+	; back to read the values out of the RTC
+	stz VERA_CTRL
+	lda @defaults+2
+	sta VERA_DC_VIDEO
+	lda @defaults+3
+	sta VERA_DC_HSCALE
+	lda @defaults+4
+	sta VERA_DC_VSCALE
+	lda @defaults+5
+	sta VERA_DC_BORDER
+	lda #2
+	sta VERA_CTRL
+	lda @defaults+6
+	sta VERA_DC_HSTART
+	lda @defaults+7
+	sta VERA_DC_HSTOP
+	lda @defaults+8
+	sta VERA_DC_VSTART
+	lda @defaults+9
+	sta VERA_DC_VSTOP
+	stz VERA_CTRL
+	lda @defaults+10
+	sta color
+	rts
+
+@defaults:
+	.byte $00
+	.byte $00,$21,$80,$80,$00,$00,$A0,$00,$F0,$61
+	.byte $03,$21,$40,$40,$00,$00,$A0,$00,$F0,$61


### PR DESCRIPTION
At David's request, I'm adding support for an at-boot configuration of screen mode, which repurposes the 40/80 key (Scroll Lock) to toggle between these two configured modes.

The feature uses the first 22 bytes of the 64 available nvram bytes in the RTC at these offsets.

```
$00 = Default mode at boot (0/1)
$01/$0B = Screen Mode (SCREEN n) default = $00/$03
$02/$0C = $9F29 (DCSEL=0)        default = $21/$21
$03/$0D = $9F2A (DCSEL=0)        default = $80/$40
$04/$0E = $9F2B (DCSEL=0)        default = $80/$40
$05/$0F = $9F2C (DCSEL=0)        default = $00/$00
$06/$10 = $9F29 (DCSEL=1)        default = $00/$00
$07/$11 = $9F2A (DCSEL=1)        default = $A0/$A0
$08/$12 = $9F2B (DCSEL=1)        default = $00/$00
$09/$13 = $9F2C (DCSEL=1)        default = $F0/$F0
$0A/$14 = bbbbffff (b = background, f = foreground) default text color (default $61)
$15 = Simple checksum (sum of the values in $00-$14 mod 256)
```

At boot time, or when the 40/80 key is pressed, the KERNAL will reconfigure the screen based on what is in nvram.  However, if it encounters any of the following conditions, it will attempt to reset the nvram config to defaults and configure the screen with the first default profile:
- The checksum byte in nvram offset $15 is wrong
- The low two bits in DC_VIDEO are both 0 (no output configured)
- any of DC_HSCALE, DC_VSCALE, DC_HSTOP, or DC_VSTOP are 0
- The configured foreground and background text colors are equal to each other

The addition to the butterfly banner is a workaround to make it look correct if the machine boots in 40 column mode. It avoids an extra newline when the `**** COMMANDER X16 BASIC V2 ****` string ends at the last screen column.

This PR also adds a hotkey combo, `SHIFT+40/80`, to toggle between composite and VGA in the editor while changing no other parameters.

Closes #23 