### PR TITLE
[BASIC] allow BANK statement to set RAM and ROM banks separately

### DIFF
--- a/basic/code17.s
+++ b/basic/code17.s
@@ -55,8 +55,13 @@ peek	lda poker+1
 	bcs peek1
 	lda (poker),y   ;Low RAM
 	jmp peek2
-peek1	lda #poker	;High RAM or ROM
-	ldx curbank
+peek3	stz ram_bank
+	ldx crombank
+	bra peek4
+peek1	cmp #$c0
+	bcs peek3
+	ldx crambank
+peek4	lda #poker	;High RAM or ROM
 	jsr fetch
 peek2	tay
 dosgfl	pla
@@ -72,11 +77,17 @@ poke	jsr getnum
 	ldy #0
 	sta (poker),y
 	rts
-pokefr	lda #poker
-	sta stavec
+pokefr2	stz ram_bank
 	txa
-	ldx curbank
-	ldy #0
+	ldx crombank
+	bra pokefr3
+pokefr ldy #poker
+	sty stavec
+	cmp #$c0
+	bcs pokefr2
+	txa
+	ldx crambank
+pokefr3	ldy #0
 	jmp stash
 fnwait	jsr getnum
 	stx andmsk

--- a/basic/code17.s
+++ b/basic/code17.s
@@ -51,12 +51,14 @@ peek	lda poker+1
 	jsr getadr0
 	ldy #0
 	lda poker+1
-	cmp #$a0
-	bcs peek1
+	cmp #$a0        ;We don't disturb $00 (ram_bank) here for a low RAM
+	bcs peek1       ;read so that it is possible to read $00 after BLOAD
 	lda (poker),y   ;Low RAM
 	jmp peek2
 peek3	stz ram_bank
 	ldx crombank
+	lda crambank
+	sta ram_bank
 	bra peek4
 peek1	cmp #$c0
 	bcs peek3
@@ -80,6 +82,8 @@ poke	jsr getnum
 pokefr2	stz ram_bank
 	txa
 	ldx crombank
+	ldy crambank
+	sty ram_bank
 	bra pokefr3
 pokefr ldy #poker
 	sty stavec

--- a/basic/code17.s
+++ b/basic/code17.s
@@ -85,7 +85,7 @@ pokefr2	stz ram_bank
 	ldy crambank
 	sty ram_bank
 	bra pokefr3
-pokefr ldy #poker
+pokefr	ldy #poker
 	sty stavec
 	cmp #$c0
 	bcs pokefr2

--- a/basic/code26.s
+++ b/basic/code26.s
@@ -86,6 +86,10 @@ csysfr2	pha             ;Far jump; extra byte on stack for return bank
 	plx
 
 	lda crombank    ;Fetch target bank, and go far!
+	pha
+	lda crambank
+	sta ram_bank
+	pla
 	jmp jsrfar3
 
 csysrz	=*-1            ;return to here

--- a/basic/code26.s
+++ b/basic/code26.s
@@ -43,8 +43,12 @@ plot	=$fff0
 
 csys	jsr frmadr      ;get int. addr
 	lda linnum+1
-	cmp #$a0
+	cmp #$c0
 	bcs csysfar
+
+	lda crambank
+	sta ram_bank
+
 	lda #>csysrz    ;push return address
 	pha
 	lda #<csysrz
@@ -57,7 +61,8 @@ csys	jsr frmadr      ;get int. addr
 	plp             ;load 6502 status reg
 	jmp (linnum)    ;go do it
 
-csysfar	jsr csysfr2
+csysfar	stz ram_bank ; for fetching crombank
+	jsr csysfr2
 	bra csysrz+1
 
 csysfr2	pha             ;Far jump; extra byte on stack for return bank
@@ -80,7 +85,7 @@ csysfr2	pha             ;Far jump; extra byte on stack for return bank
 	sta $0104,x
 	plx
 
-	lda curbank     ;Fetch target bank, and go far!
+	lda crombank    ;Fetch target bank, and go far!
 	jmp jsrfar3
 
 csysrz	=*-1            ;return to here

--- a/basic/code26.s
+++ b/basic/code26.s
@@ -93,6 +93,8 @@ csysrz	=*-1            ;return to here
 	sta sareg       ;save 6502 regs
 	stx sxreg
 	sty syreg
+	lda crambank
+	sta ram_bank
 	pla             ;get status reg
 	sta spreg
 	rts             ;return to system

--- a/basic/init.s
+++ b/basic/init.s
@@ -14,7 +14,10 @@ nready	jmp readyx
 init	jsr initv       ;go init vectors
 	jsr initcz      ;go init charget & z-page
 	jsr initms      ;go print initilization messages
-	stz curbank     ;set default value for BANK statement
+	ldx #1
+	stx crambank     ;set default value for BANK statement (RAM)
+	stz ram_bank
+	stz crombank     ;set default value for BANK statement (ROM)
 init2	ldx #stkend-256 ;set up end of stack
 	txs
 boot	lda #0

--- a/basic/init.s
+++ b/basic/init.s
@@ -14,10 +14,11 @@ nready	jmp readyx
 init	jsr initv       ;go init vectors
 	jsr initcz      ;go init charget & z-page
 	jsr initms      ;go print initilization messages
-	ldx #1
-	stx crambank     ;set default value for BANK statement (RAM)
 	stz ram_bank
 	stz crombank     ;set default value for BANK statement (ROM)
+	ldx #1
+	stx crambank     ;set default value for BANK statement (RAM)
+	stx ram_bank
 init2	ldx #stkend-256 ;set up end of stack
 	txs
 boot	lda #0

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -625,6 +625,8 @@ setbank:
 	stz ram_bank
 	stx crombank
 @done:
+	lda crambank
+	sta ram_bank
 	rts
 
 ;***************
@@ -637,6 +639,8 @@ clear_4080_flag:
 	lda shflag
 	and #255-32
 	sta shflag
+	lda crambank
+	sta ram_bank
 	rts
 
 ;***************

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -607,15 +607,24 @@ ckeymap:
 @fcerr:	jmp fcerr
 
 ;***************
-.export curbank
+.export crambank, crombank
 .segment "BVARS"
-	curbank: .res 1
+	crambank: .res 1
+.segment "BVARSB0"
+	crombank: .res 1
 
 .segment "BASIC"
 .export setbank
 setbank:
 	jsr getbyt
-	stx curbank
+	stx crambank
+	jsr chrgot
+	beq @done
+	jsr chkcom
+	jsr getbyt
+	stz ram_bank
+	stx crombank
+@done:
 	rts
 
 ;***************
@@ -624,15 +633,10 @@ setbank:
 ;to the BASIC editor to prevent 40/80 key
 ;presses during program execution to take effect
 clear_4080_flag:
-	lda ram_bank
-	pha
-	lda #BANK_KERNAL
-	sta ram_bank
+	stz ram_bank
 	lda shflag
 	and #255-32
 	sta shflag
-	pla
-	sta ram_bank
 	rts
 
 ;***************

--- a/cfg/basic-x16.cfgtpl
+++ b/cfg/basic-x16.cfgtpl
@@ -15,6 +15,7 @@ SEGMENTS {
 
 	ZPMATH:   load = ZPMATH,   type = zp;
 	FPVARS:   load = FPVARS,   type = bss;
+	BVARSB0:  load = BVARSB0,  type = bss;
 
 	BASIC:     load = BASIC,     type = ro;
 	MATH:      load = BASIC,     type = ro;

--- a/cfg/x16.cfginc
+++ b/cfg/x16.cfginc
@@ -39,7 +39,8 @@ BVARS:    start = $03D3, size = $002D; # BASIC
 
 /* KERNAL/DOS bank #0 vars */
 KEYMAP:   start = $A000, size = $0800; # the current keyboard mapping table
-KVARSB0:  start = $A800, size = $05C0; # there is a lot of space free here
+KVARSB0:  start = $A800, size = $0500; # there is a lot of space free here
+BVARSB0:  start = $AD00, size = $00C0; # BASIC expansion variables, few used
 AUDIOBSS: start = $ADC0, size = $0040; # audio bank scratch space and misc state
 BAUDIO:   start = $AE00, size = $0100; # YM2151 shadow for audio routines
 DOSDAT:   start = $B000, size = $1000; # there is a lot of space free here, too


### PR DESCRIPTION
There's a potential usability issue in the old behavior where default of `BANK 0` applied to both the ROM and RAM banks. You would ordinarily want the ROM bank to be in 0 or 4 when doing SYS calls, but before the BANK command was added, BASIC could only run SYS in ROM bank 4.  Thankfully the KERNAL jump table also already existed in ROM bank 4.

Unfortunately, the former behavior of the default RAM bank being 1 was no longer in effect after the `BANK` statement code was added.  This led people's programs that assumed RAM bank 1 was active at boot to clobber internal KERNAL variables if they used banked RAM in BASIC.

I think restoring the old default bank behavior prior to the introduction of the BANK command is the most needed part of this change, but for this to be possible, we need to be able to set the two banks separately.

There was no room left in BVARS, so `crombank` is the first to take up residence the brand new segment BVARSB0.

Closes #26 