### PR TITLE
[BASIC] Incorporate BASIC 7-like behavior for ASC()

### DIFF
--- a/basic/code16.s
+++ b/basic/code16.s
@@ -153,11 +153,11 @@ len1	jsr frestr
 	tay
 	rts
 asc	jsr len1
-	beq gofuc
+	beq asces
 	ldy #0
 	lda (index1),y
 	tay
-	jmp sngflt
+asces	jmp sngflt
 gofuc	jmp fcerr
 gtbytc	jsr chrget
 


### PR DESCRIPTION
In CBM BASIC 7, `ASC("")` returns 0.  This PR allows X16 BASIC to do the same, and avoid the need for error-checking `GET#` from a binary file.

Closes #28 