### PR TITLE
[KERNAL] initialize screen with default nvram profile for basic warm start and monitor

### DIFF
--- a/kernal/cbm/nmi.s
+++ b/kernal/cbm/nmi.s
@@ -9,11 +9,11 @@
 rom_bank = 1
 monitor = $fecc
 .import enter_basic, cint, ioinit, restor, nminv
-.import call_audio_init
+.import call_audio_init, screen_set_defaults_from_nvram
 
 .export nmi, nnmi, timb
 
-	.segment "NMI"
+.segment "NMI"
 
 ; sets up the stack just like the RAM trampoline does
 nmi	pha
@@ -27,6 +27,7 @@ nnmi	jsr ioinit           ;go initilize i/o devices
 ;
 	jsr cint             ;go initilize screen
 	jsr call_audio_init  ;initialize audio API and HW.
+	jsr screen_set_defaults_from_nvram
 
 	clc
 	jmp enter_basic
@@ -38,6 +39,8 @@ timb	jsr restor      ;restore system indirects
 	jsr ioinit      ;restore i/o for basic
 	jsr cint        ;restore screen for basic
 	jsr call_audio_init  ;initialize audio API and HW.
+	jsr screen_set_defaults_from_nvram
+
 	clc
 	jmp monitor
 


### PR DESCRIPTION
Reaching warm start through NMI and reaching the monitor through BRK would always reset the screen mode to 0 and output device to VGA.  This change uses the profile from nvram instead.