### PR TITLE
[CODEX] fix plugin config file so that the ROM as a whole builds on latest cc65/ca65

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
           sudo apt-get install -y make build-essential
           git clone https://github.com/cc65/cc65.git
           cd cc65
-          git checkout c097401f8bd907b3994b68e7e8b47d50b4a1864c
           make -j4
           sudo make install
       - name: Build ROM

--- a/codex/.gitignore
+++ b/codex/.gitignore
@@ -1,6 +1,7 @@
 cx
 cx-dc
 cx-mii
+cx-sym
 utest
 *.map
 *.sym

--- a/codex/cfg/cx-plugin.cfg
+++ b/codex/cfg/cx-plugin.cfg
@@ -9,7 +9,7 @@ MEMORY {
     ZP:        file = "", define = yes, start = $0022,                size = $0080 - $0022;
     PLUGIN:    file = %O,               start = %S - 2,               size = $5;
     RWRAM:     file = "",               start = $0400,                size = $3FF;
-    MAIN:      file = %O, define = yes, start = %S + $3,              size = $2000 - %S;
+    MAIN:      file = %O, define = yes, start = %S + $3,              size = $2000 - $3;
     BANK:      file = "",               start = $A000,                size = $2000;
 }
 SEGMENTS {


### PR DESCRIPTION
I don't know if this correct, but it does allow it to build.

Also, added a build artifact filename to codex/.gitignore