### PR TITLE
[BASIC] add optional line number for RESTORE statement

### DIFF
--- a/basic/code2.s
+++ b/basic/code2.s
@@ -205,7 +205,7 @@ cleart	lda memsiz      ;entry for open & close memsiz changes
 	sty arytab+1
 	sta strend
 	sty strend+1
-fload	jsr restor
+fload	jsr restor2     ;ARGless BASIC 2 restore
 stkini	ldx #tempst
 	stx temppt
 	pla 

--- a/basic/code4.s
+++ b/basic/code4.s
@@ -70,7 +70,22 @@ snerrx	cmp #gotk-endtk
 	lda #totk
 	jsr synchr
 	jmp goto
-restor	sec
+restor	beq restor2 ; no argument, do BASIC 2 behavior
+	jsr linget ; otherwise get line number argument
+	jsr fndlin ; search for its address (slow, always from the beginning)
+	bcc resterr ; couldn't find?
+	lda lowtr ; set the data ptr to the byte before the found line
+	sbc #1
+	sta datptr
+	lda lowtr+1
+	sbc #0
+	sta datptr+1
+	rts
+resterr
+	ldx #errus
+	jmp error
+restor2
+	sec
 	lda txttab
 	sbc #1
 	ldy txttab+1


### PR DESCRIPTION
Are you sure this is BASIC 2? Because this doesn't behave like BASIC 2 ;)

![image](https://user-images.githubusercontent.com/395186/222944399-f4ce0b6a-1522-464d-b1c6-3072c79903d2.png)

`RESTORE <n>` moves the `DATA` pointer to first `DATA` statement at or following line number `<n>`   `RESTORE` without a parameter retains the BASIC 2 behavior of resetting it to the first `DATA` statement.