### PR TITLE
[BASIC] add REBOOT, POWEROFF, SLEEP, I2CPOKE, I2CPEEK, and BSAVE

### DIFF
--- a/basic/token2.s
+++ b/basic/token2.s
@@ -111,6 +111,7 @@ reslst3
 	.byt "POWEROF", 'F' + $80
 	.byt "I2CPOK", 'E' + $80
 	.byt "SLEE", 'P' + $80
+	.byt "BSAV", 'E' + $80
 	
 	; add new statements before this line
 
@@ -134,6 +135,7 @@ err01	.byt "TOO MANY FILE",$d3
 err02	.byt "FILE OPE",$ce
 err03	.byt "FILE NOT OPE",$ce
 err04	.byt "FILE NOT FOUN",$c4
+errfnf  = 4
 err05	.byt "DEVICE NOT PRESEN",$d4
 errnp	=5
 err06	.byt "NOT INPUT FIL",$c5

--- a/basic/token2.s
+++ b/basic/token2.s
@@ -100,12 +100,18 @@ reslst2	.byt "MO", 'N' + $80
 	.byt "PSGFRE", 'Q' + $80
 	.byt "PSGPA", 'N' + $80
 	.byt "PSGPLA", 'Y' + $80
+	.byt "PSGCHOR", 'D' + $80
 	.byt 0 ; keep this last
 	; The division between reslst2 and reslst3 is arbitrary, but the order
 	; must be maintained. Parser will check all of reslst2 and then
 	; continue onward with checking entries in reslst3.
-reslst3	.byt "PSGCHOR", 'D' + $80
-
+	; realst2 is very close to max length.
+reslst3	
+	.byt "REBOO", 'T' + $80
+	.byt "POWEROF", 'F' + $80
+	.byt "I2CPOK", 'E' + $80
+	.byt "SLEE", 'P' + $80
+	
 	; add new statements before this line
 
 	; functions start here
@@ -116,6 +122,7 @@ reslst3	.byt "PSGCHOR", 'D' + $80
 	.byt "JO", 'Y' + $80
 	.byt "HEX", $a4
 	.byt "BIN", $a4
+	.byt "I2CPEE", 'K' + $80
 
 	; add new functions before this line
 	.byt 0
@@ -128,6 +135,7 @@ err02	.byt "FILE OPE",$ce
 err03	.byt "FILE NOT OPE",$ce
 err04	.byt "FILE NOT FOUN",$c4
 err05	.byt "DEVICE NOT PRESEN",$d4
+errnp	=5
 err06	.byt "NOT INPUT FIL",$c5
 err07	.byt "NOT OUTPUT FIL",$c5
 err08	.byt "MISSING FILE NAM",$c5

--- a/basic/tokens.s
+++ b/basic/tokens.s
@@ -132,6 +132,7 @@ stmdsp2	; statements
 	.word poweroff-1
 	.word i2cpoke-1
 	.word sleep-1
+	.word cbsave-1
 
 	; functions
 ptrfunc	.word vpeek

--- a/basic/tokens.s
+++ b/basic/tokens.s
@@ -128,6 +128,10 @@ stmdsp2	; statements
 	.word psgpan-1
 	.word psgplay-1
 	.word psgchord-1
+	.word reboot-1
+	.word poweroff-1
+	.word i2cpoke-1
+	.word sleep-1
 
 	; functions
 ptrfunc	.word vpeek
@@ -137,6 +141,7 @@ ptrfunc	.word vpeek
 	.word joy
 	.word hexd
 	.word bind
+	.word i2cpeek
 ptrend
 num_esc_statements = (ptrfunc - stmdsp2) / 2
 num_esc_functions = (ptrend - ptrfunc) / 2

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -821,6 +821,37 @@ sleep:
 @end:
 	rts
 
+; BSAVE "FILENAME",<device>,<bank>,<start address>,<end address>
+cbsave:
+	jsr plsvbin     ;parse file-related parms up to and including start address
+	bcs @error      ;require bank/address parms
+	; Preserve the start address
+	ldx poker
+	phx
+	ldy poker+1
+	phy
+	jsr chkcom
+	jsr frmadr
+	ldx andmsk      ;switch to the requested bank
+	stx ram_bank
+	ldx poker
+	ldy poker+1
+	pla
+	sta poker+1
+	pla
+	sta poker
+	lda #<poker
+	jsr bsave       ;save it headerless
+	bcc :+
+	ldx #errfnf
+	jmp error
+@error:
+	ldx #errsn
+	jmp error
+:	rts
+
+
+
 ; BASIC's entry into jsrfar
 .setcpu "65c02"
 ram_bank = 0

--- a/dos/README.md
+++ b/dos/README.md
@@ -42,7 +42,7 @@ Or the core feature set, these are the supported functions:
 |---------------------------|-------------------------------|-----------|---------|
 | Reading                   | `,?,R`                        | yes       |         |
 | Writing                   | `,?,W`                        | yes       |         |
-| Appending                 | `,?,A`                        | not yet   |         |
+| Appending                 | `,?,A`                        | yes   |         |
 | Recovery                  | `,?,M`                        | no        | not useful on FAT32 |
 | Types                     | `,S`/`,P`/`,U`/`,L`           | yes       | ignored on FAT32 |
 | Overwriting               | `@:`                          | yes       |         |

--- a/dos/file.s
+++ b/dos/file.s
@@ -97,8 +97,13 @@ file_open:
 	lda channel
 	beq @open_read
 	cmp #1
-	beq @open_write
-
+	bne @check_mode
+	; allow append w/ channel 1 (needed for stacking BSAVEs)
+	lda file_mode
+	cmp #'A'
+	beq @open_append
+	bra @open_write
+@check_mode:
 	; otherwise check the mode
 	lda file_mode
 	cmp #'W'

--- a/inc/kernal.inc
+++ b/inc/kernal.inc
@@ -136,3 +136,5 @@ i2c_write_byte               = $fec9
 kbdbuf_peek                  = $febd
 kbdbuf_get_modifiers         = $fec0
 kbdbuf_put                   = $fec3
+
+bsave                        = $feba

--- a/kernal/cbm/channel/channel.s
+++ b/kernal/cbm/channel/channel.s
@@ -91,6 +91,8 @@ untlk = $ffab
 .export status
 .export sal, sah
 
+.export savehl
+
 .segment "ZPCHANNEL" : zeropage
 ;                      C64 location
 ;                         VVV

--- a/kernal/cbm/channel/save.s
+++ b/kernal/cbm/channel/save.s
@@ -14,8 +14,13 @@
 ;*start of save is indirect at .a  *
 ;*end of save is .x,.y             *
 ;***********************************
-
-savesp	stx eal
+savehl	pha ; headerless
+	lda #1
+	sta verck
+	pla
+	bra :+
+savesp	stz verck   ; verck is 0 for a normal headered save
+:	stx eal
 	sty eah
 	tax             ;set up start
 	lda $00,x
@@ -47,6 +52,8 @@ sv25	jsr openi
 	jsr secnd
 	ldy #0
 	jsr rd300
+	lda verck
+	bne sv30      ; check for headerless
 	lda sal
 	jsr ciout
 	lda sah

--- a/kernal/vectors.s
+++ b/kernal/vectors.s
@@ -29,6 +29,8 @@
 
 .import restor, memtop, membot, vector, puls, start, nmi, iobase, primm
 
+.import savehl
+
 	.segment "JMPTBL"
 
 ; *** this is space for new X16 KERNAL vectors ***
@@ -41,7 +43,7 @@
 	.byte 0,0,0                    ; $FEB1
 	.byte 0,0,0                    ; $FEB4
 	.byte 0,0,0                    ; $FEB7
-	.byte 0,0,0                    ; $FEBA
+	jmp savehl                     ; $FEBA
 
 	jmp kbdbuf_peek                ; $FEBD
 	jmp kbdbuf_get_modifiers       ; $FEC0

--- a/kernsup/kernsup.inc
+++ b/kernsup/kernsup.inc
@@ -4,7 +4,7 @@
 .byte 0,0,0                       ; $FEB1
 .byte 0,0,0                       ; $FEB4
 .byte 0,0,0                       ; $FEB7
-.byte 0,0,0                       ; $FEBA
+bridge bsave                      ; $FEBA
 
 bridge kbdbuf_peek                ; $FEBD
 bridge kbdbuf_get_modifiers       ; $FEC0


### PR DESCRIPTION
The new I2C* keywords are generic for the entire I2C bus, not just for the SMC. The microcontroller address is $42

I'm leaving RESET as is, just jumps through the reset vector,
adds REBOOT as equivalent to the reset button push
adds POWEROFF which does work on both hardware and emu
adds the SLEEP command, parameter is in jiffies.  SLEEP without an argument is the same as SLEEP 0, which waits for until the next interrupt.  Rephrased, it will sleep this many whole jiffies plus a partial one.

Closes #36 
