### PR TITLE
[BASIC] inappropriate string length checking for KEYMAP's argument

### DIFF
--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -588,7 +588,7 @@ locate:
 ;***************
 ckeymap:
 	jsr frmstr
-	cmp #6
+	cmp #10
 	bcs @fcerr
 	tay
 	lda #0


### PR DESCRIPTION
The BASIC `KEYMAP` routine treats the string parameter with a length > 5 as invalid, even though we have layouts that exceed this length.  Upped the max length to 9.

Closes #39 