### PR TITLE
[KERNAL/BASIC] use default color value when unable to read nvram for it

### DIFF
--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -700,7 +700,8 @@ rtc_address            = $6f
 nvram_base             = $20
 
 ; This is a mirror of the internal kernal routine by the same name
-; but it only sets the fg color
+; but it only sets the fg color.  This is called after the splash
+; banner, which has messed with the colors itself
 screen_default_color_from_nvram:
 	ldy #nvram_base+0
 	ldx #rtc_address
@@ -716,6 +717,9 @@ screen_default_color_from_nvram:
 	tay
 	ldx #rtc_address
 	jsr i2c_read_byte
+	bcc :+
+	lda #$61 ; hardcode value on i2c error
+:
 
 	sta facho ; tmp variable
 

--- a/kernal/drivers/x16/screen.s
+++ b/kernal/drivers/x16/screen.s
@@ -215,6 +215,8 @@ screen_mode:
 	and #$ef
 	sta VERA_DC_VIDEO
 	jsr screen_default_color_from_nvram ; was $61, blue on white
+	bcc @cont
+	lda #$61 ; didn't get a valid value from NVRAM, hardcode it
 	bra @cont
 
 @graph:	; graphics mode
@@ -765,6 +767,7 @@ screen_set_mode_from_nvram:
 screen_default_color_from_nvram:
 	ldy #0
 	jsr rtc_get_nvram
+	bcs @exit
 
 	and #1
 	beq :+
@@ -798,6 +801,7 @@ screen_default_color_from_nvram:
 	ora tmp2
 :
 	clc
+@exit:
 	rts
 
 screen_set_default_nvram:

--- a/kernal/drivers/x16/screen.s
+++ b/kernal/drivers/x16/screen.s
@@ -778,6 +778,7 @@ screen_default_color_from_nvram:
 	adc #10 ; color offset
 	tay
 	jsr rtc_get_nvram
+	bcs @exit
 
 	sta tmp2
 


### PR DESCRIPTION
Closes #51 