### PR TITLE
[BUILD] add git signature

### DIFF
--- a/basic/init.s
+++ b/basic/init.s
@@ -190,6 +190,9 @@ freme2	.byt "K HIGH RAM"
 	.byte ((PRERELEASE_VERSION / 10) .mod 10) + '0'
 .endif
 	.byte (PRERELEASE_VERSION .mod 10) + '0'
+.else
+	.byte " - GIT "
+	.incbin "../build/signature.bin"
 .endif
 	.byt $0d
 	; line 4

--- a/cfg/kernal-x16.cfgtpl
+++ b/cfg/kernal-x16.cfgtpl
@@ -1,7 +1,8 @@
 MEMORY {
 	#include "x16.cfginc"
 
-	KERNAL:   start = $C000, size = $3EA8, fill=yes, fillval=$AA;
+	SIGNATURE:start = $C000, size = $0010, fill=yes, fillval=$00;
+	KERNAL:   start = $C010, size = $3E98, fill=yes, fillval=$AA;
 	JMPTBL:   start = $FEA8, size = $0152, fill=yes, fillval=$AA;
 	VECTORS:  start = $FFFA, size = $0006, fill=yes, fillval=$AA;
 }
@@ -22,6 +23,7 @@ SEGMENTS {
 	KVARSB0:    load = KVARSB0,  type = bss, define=yes;
 	USERPARM:   load = USERPARM, type = bss;
 
+	SIGNATURE:load = SIGNATURE,   type = ro;
 	EDITOR:   load = KERNAL,   type = ro;
 	SCREEN:   load = KERNAL,   type = ro;
 	KBDBUF:   load = KERNAL,   type = ro;

--- a/kernal/signature.s
+++ b/kernal/signature.s
@@ -1,0 +1,9 @@
+;----------------------------------------------------------------------
+; ROM build signature
+;----------------------------------------------------------------------
+
+.export rom_signature
+
+.segment "SIGNATURE"
+rom_signature:
+.incbin "../build/signature.bin"


### PR DESCRIPTION
Up until this point, it has been difficult to determine what era, revision, or capabilities a ROM build has.  This is an attempt at solving that.  It creates a programmatically readable signature at the beginning of ROM bank 0.  16 bytes have been reserved for this purpose.

It currently contains the short git hash (8 hex digits), with a + if the repo has diverged from the commit.  This string is also in the BASIC banner.

More dependency fixes are needed in the Makefile, but this is a start. 