### PR TITLE
[KERNAL] support hardware vector pull in B0 IRQ vector

### DIFF
--- a/kernal/cbm/irq.s
+++ b/kernal/cbm/irq.s
@@ -10,7 +10,7 @@
 
 .export puls, key
 
-	.segment "IRQ"
+.segment "IRQ"
 
 .import screen_init
 .import mouse_scan
@@ -20,9 +20,19 @@
 .import led_update
 .export panic
 
+.include "banks.inc"
+
+rom_bank = 1
+
+
 ; puls - checks for real irq's or breaks
 ;
 puls	pha
+	lda rom_bank
+	beq :+
+	pla
+	jmp banked_irq
+:
 .ifp02
 	txa
 	pha


### PR DESCRIPTION
Later generations of X16 may act on the assertion of the VPB pin on the 65C02 by resetting the ROM bank latches to 0 before the processor reads the vector table.  This would enter KERNAL IRQ in ROM bank 0 while the zeropage address $01 still contains the bank that was active before the IRQ.

This code change supports that possibility by checking whether ZP $01 contains a value other than 0, and if so, runs the banked IRQ routine, so that the return goes to the previously active bank.

This adds 6 clock cycles to the beginning of a B0 IRQ and 18 clocks to a nonzero-bank IRQ on such future potential hardware.  It also adds 6 clocks to a nonzero-bank IRQ on current hardware without vector pull.