### PR TITLE
[BASIC] Provide feedback for SAVE in direct mode

### DIFF
--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -357,7 +357,7 @@ ptstat2	php
 	rts
 :	jsr unlstn
 	jsr getfa
-	jsr talk
+ptstat3	jsr talk
 	lda #$6f
 	jsr tksa
 dos11	jsr iecin


### PR DESCRIPTION
When using SAVE in BASIC direct mode, we should immediately return the error or lack thereof to the user.  This is a compromise between those who are frustrated with the lack of apparent feedback and for others, including David, who want CMDR-DOS to maintain the 1541-like behaviors.  This clears the drive error status implicitly.

This new behavior does not happen if `SAVE` is used within a program, as rare as that might be, so that the user can still check programmatically for error status. It only affects direct mode.

![image](https://user-images.githubusercontent.com/395186/225764559-d7085fae-88e2-47c2-ab6b-1ef29aaf56fd.png)
