### PR TITLE
[KERNAL] add new bordered screen modes

### DIFF
--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -505,7 +505,7 @@ wlogic
 	cmp pntr        ;if lnmx is less than pntr
 	bcs wlgrts      ;branch if lnmx>=pntr
 	cmp #maxchr-1   ;past max characters
-	beq wlog10      ;branch if so
+	bcs wlog10      ;branch if so
 	lda autodn      ;should we auto scroll down?
 	beq wlog20      ;branch if not
 	jmp bmt1        ;else decide which way to scroll
@@ -809,7 +809,7 @@ up5	ldx qtsw
 	cpy pntr
 	bne ins1
 ins3	cpy #maxchr-1
-	beq insext      ;exit if line too long
+	bcs insext      ;exit if line too long
 	jsr newlin      ;scroll down 1
 ins1	ldy lnmx
 ; move line right


### PR DESCRIPTION
This change adds modes 7-11 which include borders.  These modes are meant for CRT displays, have a defined border size, and avoid non-power-of-two scaling.

This discussion came up today with Adrian Black testing various modes on his CRTs, and finding that nearest neighbor vertical scaling (VSCALE something other than a power of two) on a CRT doesn't look good.

Native modes that can easily be reached from BASIC seem like the right answer.