### PR TITLE
[BASIC] handle 1541-style null-terminated errors

### DIFF
--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -361,13 +361,14 @@ ptstat3	jsr talk
 	lda #$6f
 	jsr tksa
 dos11	jsr iecin
+	beq dos0
 	plp
 	php
 	bcc :+
 	jsr bsout
 :	cmp #13
 	bne dos11
-	plp
+dos0	plp
 	jmp untalk
 
 ;***************

--- a/monitor/io.s
+++ b/monitor/io.s
@@ -227,10 +227,11 @@ ptstat	jsr listen_cmd
 	jsr tksa
 	jsr print_cr
 dos11	jsr iecin
+	beq dos0
 	jsr bsout
 	cmp #13
 	bne dos11
-	jsr untalk
+dos0	jsr untalk
 	jmp input_loop
 
 ;***************


### PR DESCRIPTION
The BASIC `DOS` command and the `clear_status` routine would not handle errors not terminated by a CR.  The 1541 omits the CR in its channel 15 error strings.

This solves the freeze at boot with an IEC drive attached as device 8