### PR TITLE
f-key reorg

### DIFF
--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -1169,10 +1169,10 @@ runtb	.byt "LOAD",$d,"RUN:",$d
 runtb_end:
 
 fkeytb	.byt "LIST:", 13, 0
-	.byt "MONITOR:", 13, 0
-	.byt "RUN:", 13, 0
-	.byt $93, "S", 'C' + $80, "-1", 13, 0
-	.byt "LOAD", 13, 0
 	.byt "SAVE", '"', 0
+	.byt "LOAD ", '"', 0
+	.byt $93, "S", 'C' + $80, "-1", 13, 0
+	.byt "RUN:", 13, 0
+	.byt "MONITOR:", 13, 0
 	.byt "DOS",'"', "$",13, 0
 	.byt "DOS", '"', 0


### PR DESCRIPTION
This changes the f-key assignments slightly:
F2=`SAVE "`
F3=`LOAD "` (note the space and quote. This lets you load directly from a file listing.)
F5=`RUN`
F6=`MONITOR`

This is more consistent with other programs' use of these keys. Also so LOAD<cr> doesn't wipe out programs in progress. (Also, I'm tired of losing work because I tap F5 when I meant to tap F4.)

Previously, F5 LOADed with a CR, which wiped out the current BASIC program. This change fixes that. It also puts the F-keys in more consistent positions for those of us used to 80s era text editors. 