### PR TITLE
[KERNAL/EDITOR] add missing jmp after checking for HOME key which only caused a problem on 32 column modes

### DIFF
--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -681,6 +681,7 @@ nc3w	cmp #$12
 nc1	cmp #$13
 	bne nc2
 	jsr nxtd
+	jmp loop2
 nc2	cmp #$04        ;END
 	bne nc25
 	stz pntr        ;column


### PR DESCRIPTION
`nxtd` molests the A register.  What comes out of that subroutine is A = the number of screen columns - 1.  The missing jmp didn't matter for what followed if it was a 20/40/80 column mode because 19/39/79 did not match any PETSCII compares that followed.  In fact, 19, is $13, which matches the Home petscii code already!  The other two are in the printable range and are not checked.

This also didn't break for 64 column modes because 63 was also in the printable range.

In 32 column mode, 31 (or $1f) matches the code for Blue, or color 6, which was then set after hitting HOME in 32-column mode.  This change avoids that behavior.