### PR TITLE
[BASIC] Enhance DOS to display status after channel command, ensure similar behavior for SAVE command

### DIFF
--- a/basic/code26.s
+++ b/basic/code26.s
@@ -114,10 +114,8 @@ nsnerr6	lda verck   ;fetch the device (fa) that was used
 	jsr $ffd8       ;save it
 	bcc :+
 	jmp erexit      ;extra value in stack does not matter
-:	lda curlin      ;in direct mode, show save status
-	bne :+
-	lda curlin+1
-	cmp #255
+:	lda curlin+1    ;in direct mode, show save status
+	inc
 	bne :+
 	lda #$0d
 	jsr bsout

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -315,7 +315,11 @@ dos	beq ptstat      ;no argument: print status
 	iny
 	cpy verck       ;length?
 	bne :-
-	jmp unlstn
+	jsr unlstn
+	lda curlin+1
+	inc
+	beq ptstat
+	rts
 
 ; in:  C=1 show "DEVICE NOT PRESENT" on error
 ;      C=0 return error in C


### PR DESCRIPTION
Enhance `DOS` command to return status of channel command if called from direct/immediate mode.

`curlin+1` == `$FF` is the condition for direct mode.  I was mistaken that I needed to check `curlin` for zero as well.   This caused checks for direct/immediate mode to fail after running a program.