### PR TITLE
[KERNAL] change F2/F4 behavior, remove F9, remove assumption in editor that we are in BASIC, remove inaccurate comment

### DIFF
--- a/kernal/cbm/channel/errorhandler.s
+++ b/kernal/cbm/channel/errorhandler.s
@@ -10,8 +10,6 @@
 ;* return z flag set if flag true.     *
 ;* also closes active channels and     *
 ;* flushes keyboard queue.             *
-;* also returns key downs from last    *
-;* keyboard row in .a.                 *
 ;***************************************
 nstop	jsr kbdbuf_get_stop;check stop key
 	bne stop2       ;not down

--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -276,7 +276,11 @@ loop3
 	and #MODIFIER_SHIFT
 	bne scrpnc
 	jsr screen_toggle_default_nvram
-	bra doredy
+	tsx
+	lda $106,x
+	cmp #4 ; only if we came from BASIC do we print READY.
+	beq doredy
+	bra loop3b
 scrpnc
 	; screen panic, cycle through VGA/composite/RGB modes
 	stz VERA_CTRL
@@ -1178,10 +1182,10 @@ runtb	.byt "LOAD",$d,"RUN:",$d
 runtb_end:
 
 fkeytb	.byt "LIST:", 13, 0
-	.byt "SAVE", '"', 0
+	.byt "SAVE", '"', "@:", 0
 	.byt "LOAD ", '"', 0
-	.byt $93, "S", 'C' + $80, "-1", 13, 0
+	.byt "S", 'C' + $80, "-1:REM", 0
 	.byt "RUN:", 13, 0
-	.byt "MONITOR:", 13, 0
+	.byt "MONITOR:REM X TO EXIT", 13, 0
 	.byt "DOS",'"', "$",13, 0
 	.byt "DOS", '"', 0

--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -1186,6 +1186,6 @@ fkeytb	.byt "LIST:", 13, 0
 	.byt "LOAD ", '"', 0
 	.byt "S", 'C' + $80, "-1:REM", 0
 	.byt "RUN:", 13, 0
-	.byt "MONITOR:REM X TO EXIT", 13, 0
+	.byt "MONITOR:", 13, 0
 	.byt "DOS",'"', "$",13, 0
 	.byt "DOS", '"', 0

--- a/kernal/drivers/x16/ps2kbd.s
+++ b/kernal/drivers/x16/ps2kbd.s
@@ -187,25 +187,6 @@ kbd_getsrc:
 	rts
 
 
-; cycle keyboard layouts
-cycle_layout:
-	ldx curkbd
-	inx
-	txa
-:	jsr _kbd_config
-	lda #0
-	bcs :-          ;end of list? use 0
-; put name into keyboard buffer
-	ldx #0
-:	lda kbdnam,x
-	beq :+
-	jsr kbdbuf_put
-	beq :+
-	inx
-	bra :-
-:	lda #$8d ; shift + cr
-	jmp kbdbuf_put
-
 ;---------------------------------------------------------------
 ; Get/Set keyboard layout
 ;
@@ -276,8 +257,6 @@ _kbd_scan:
 	cpx #0
 	jne down_ext
 ; *** regular scancodes
-	cpy #$01 ; f9
-	beq cycle_layout
 	cmp #$84 ; Eat weird Alt + PrtScr scan code
 	bne :+
 	rts


### PR DESCRIPTION
This change
* makes F2 suggest SAVE with overwrite
* doesn't press enter on F4 (SCREEN -1)
* removes keymap cycling using F9.  Use `MENU` and select a keymap from the control panel instead
* pressing 40/80 (scroll lock) while in a keyboard BASIN routine no longer assumes we're in BASIC and prints "READY.".  It checks the stack for the calling bank. If it's 4, then it prints "READY." otherwise it prints nothing.  This is still not perfect because hitting 40/80 during a BASIC `INPUT` will still print `READY.`  It might be worth removing this guesswork and never printing anything.
* remove part of a comment in `nstop` which is likely of C64 origin, but does not have the indicated behavior on X16.