### PR TITLE
[BASIC/DOS/MONITOR/DEMO] Cleaned up warnings re using absolute addressing for ZP locations

### DIFF
--- a/basic/basic.s
+++ b/basic/basic.s
@@ -12,6 +12,9 @@
 ; for emulator
 .global vartab
 
+ram_bank = 0
+rom_bank = 1
+
 .include "declare.s"
 .include "tokens.s"
 .include "token2.s"

--- a/basic/code10.s
+++ b/basic/code10.s
@@ -40,7 +40,7 @@ isvret	sta facmo
 	jsr clock_get_date_time
 
 	; seconds
-	lda r2H
+	lda z:r2H
 	jsr component2ascii
 
 	lda lofbuf+3
@@ -49,7 +49,7 @@ isvret	sta facmo
 	pha
 
 	; minutes
-	lda r2L
+	lda z:r2L
 	jsr component2ascii
 
 	lda lofbuf+3
@@ -58,7 +58,7 @@ isvret	sta facmo
 	pha
 
 	; hours
-	lda r1H
+	lda z:r1H
 	jsr component2ascii
 
 	; Hours is at lofbuf+2.  But strings that start at lofbuf
@@ -94,15 +94,15 @@ tstr10	cpx #'D'
 	bne tstr11
 
 	jsr clock_get_date_time
-	lda r1L
-	ora r0H
-	ora r0L
+	lda z:r1L
+	ora z:r0H
+	ora z:r0L
 	bne :+
 	sta lofbuf+1
 	jmp strlitl
 :
 	; day
-	lda r1L
+	lda z:r1L
 	jsr component2ascii
 
 	lda lofbuf+3
@@ -111,7 +111,7 @@ tstr10	cpx #'D'
 	pha
 
 	; month
-	lda r0H
+	lda z:r0H
 	jsr component2ascii
 
 	lda lofbuf+3
@@ -120,7 +120,7 @@ tstr10	cpx #'D'
 	pha
 
 	; year
-	lda r0L
+	lda z:r0L
 	clc
 	adc #<1900
 	tay

--- a/basic/code6.s
+++ b/basic/code6.s
@@ -27,7 +27,7 @@ inpcom
 	jsr getadr
 	cpy #24
 	bcs fcerr2
-	sty r1H
+	sty z:r1H
 
 	; minutes
 	jsr zerofc
@@ -39,7 +39,7 @@ inpcom
 	jsr getadr
 	cpy #60
 	bcs fcerr2
-	sty r2L
+	sty z:r2L
 
 	; seconds
 	jsr zerofc
@@ -51,7 +51,7 @@ inpcom
 	jsr getadr
 	cpy #60
 	bcs fcerr2
-	sty r2H
+	sty z:r2H
 
 	jmp clock_set_date_time
 
@@ -94,7 +94,7 @@ asgndt
 	txa
 	sbc #>1900
 	bne fcerr2 ; YY < 1900 or YY > 1900+255
-	sty r0L
+	sty z:r0L
 
 	; month
 	jsr zerofc
@@ -108,7 +108,7 @@ asgndt
 	beq fcerr2 ; MM == 0
 	cmp #13
 	bcs fcerr2 ; MM > 12
-	sta r0H
+	sta z:r0H
 
 	; day
 	jsr zerofc
@@ -122,7 +122,7 @@ asgndt
 	beq fcerr2 ; DD == 0
 	cmp #32
 	bcs fcerr2 ; DD > 32
-	sta r1L
+	sta z:r1L
 
 	jmp clock_set_date_time
 

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -868,8 +868,6 @@ cmenu:
 
 ; BASIC's entry into jsrfar
 .setcpu "65c02"
-ram_bank = 0
-rom_bank = 1
 .export bjsrfar
 bjsrfar:
 .include "jsrfar.inc"

--- a/demo/test.s
+++ b/demo/test.s
@@ -485,8 +485,8 @@ test14_image:
 
 checksum_framebuffer:
 	lda #$ff
-	sta crclo
-	sta crchi
+	sta z:crclo
+	sta z:crchi
 
 	ldx #0
 @loop:	LoadW r0, 0
@@ -530,7 +530,7 @@ checksum_framebuffer:
 	lda #1
 	jsr GRAPH_set_colors
 
-	lda crchi
+	lda z:crchi
 	lsr
 	lsr
 	lsr
@@ -539,13 +539,13 @@ checksum_framebuffer:
 	lda hextab,x
 	jsr GRAPH_put_char
 
-	lda crchi
+	lda z:crchi
 	and #15
 	tax
 	lda hextab,x
 	jsr GRAPH_put_char
 
-	lda crclo
+	lda z:crclo
 	lsr
 	lsr
 	lsr
@@ -554,7 +554,7 @@ checksum_framebuffer:
 	lda hextab,x
 	jsr GRAPH_put_char
 
-	lda crclo
+	lda z:crclo
 	and #15
 	tax
 	lda hextab,x
@@ -570,32 +570,32 @@ crclo	=r7         ; current value of CRC
 crchi	=r7+1       ; not necessarily contiguous
 
 crc16_f:
-	eor crchi       ; A contained the data
-	sta crchi       ; XOR it into high byte
+	eor z:crchi       ; A contained the data
+	sta z:crchi       ; XOR it into high byte
 	lsr             ; right shift A 4 bits
 	lsr             ; to make top of x^12 term
 	lsr             ; ($1...)
 	lsr
 	tax             ; save it
 	asl             ; then make top of x^5 term
-	eor crclo       ; and XOR that with low byte
-	sta crclo       ; and save
+	eor z:crclo       ; and XOR that with low byte
+	sta z:crclo       ; and save
 	txa             ; restore partial term
-	eor crchi       ; and update high byte
-	sta crchi       ; and save
+	eor z:crchi       ; and update high byte
+	sta z:crchi       ; and save
 	asl             ; left shift three
 	asl             ; the rest of the terms
 	asl             ; have feedback from x^12
 	tax             ; save bottom of x^12
 	asl             ; left shift two more
 	asl             ; watch the carry flag
-	eor crchi       ; bottom of x^5 ($..2.)
+	eor z:crchi       ; bottom of x^5 ($..2.)
 	tay             ; save high byte
 	txa             ; fetch temp value
 	rol             ; bottom of x^12, middle of x^5!
-	eor crclo       ; finally update low byte
-	sta crchi       ; then swap high and low bytes
-	sty crclo
+	eor z:crclo       ; finally update low byte
+	sta z:crchi       ; then swap high and low bytes
+	sty z:crclo
 	rts
 
 

--- a/dos/file.s
+++ b/dos/file.s
@@ -257,7 +257,7 @@ file_read:
 ; Out:  y:x  number of bytes read
 ;       c    =1: error or EOF (no bytes received)
 ;---------------------------------------------------------------
-.import krn_ptr1
+.importzp krn_ptr1
 file_read_block:
 	stx fat32_ptr
 	sty fat32_ptr + 1

--- a/monitor/io.s
+++ b/monitor/io.s
@@ -23,7 +23,7 @@ verck  = zp3
 .import syntax_error
 .import byte_to_hex_ascii
 .import tmp16
-.import mon_fa
+.importzp mon_fa
 .importzp zp1
 .importzp zp2
 .importzp zp3

--- a/monitor/monitor.s
+++ b/monitor/monitor.s
@@ -1375,23 +1375,23 @@ s_regs: .byte	CR, "   PC  IRQ  BK AC XR YR SP NV#BDIZC", CR, 0
 
 command_names:
 	.byte "M" ; N.B.: code relies on "M" being the first entry of this table!
-command_index_d = * - command_names
+command_index_d = <(* - command_names)
 	.byte "D"
 	.byte ":"
 	.byte "A"
 	.byte "G"
 	.byte "X"
-command_index_f = * - command_names
+command_index_f = <(* - command_names)
 	.byte "F"
-command_index_h = * - command_names
+command_index_h = <(* - command_names)
 	.byte "H"
-command_index_c = * - command_names
+command_index_c = <(* - command_names)
 	.byte "C"
 	.byte "T"
 	.byte "R"
-command_index_l = * - command_names
+command_index_l = <(* - command_names)
 	.byte "L"
-command_index_s = * - command_names
+command_index_s = <(* - command_names)
 	.byte "S"
 	.byte ","
 	.byte "O"
@@ -1401,7 +1401,7 @@ command_index_s = * - command_names
 	.byte "E"
 	.byte "["
 	.byte "]"
-command_index_i = * - command_names
+command_index_i = <(* - command_names)
 	.byte "I"
 	.byte "'"
 	.byte ";"


### PR DESCRIPTION
Particularly important for `ram_bank` and `rom_bank`.  A suspected timing violation on Proto 4 is causing the instruction  `st_ $0000` (absolute) to sometimes glitch to changing the ROM bank latch, depending on the address of the `st_` instruction.