### PR TITLE
fdisk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,10 @@ DOS_SOURCES = \
 	dos/geos.s
 
 UTILITY_SOURCES = \
-	utility/fdisk.s
+	kernsup/kernsup_utility.s \
+	utility/commands.s \
+	utility/fdisk.s \
+	utility/jumptab.s
 
 GEOS_SOURCES= \
 	geos/kernal/bitmask/bitmask2.s \
@@ -333,7 +336,8 @@ UTILITY_DEPS = \
 	dos/fat32/lib.inc \
 	dos/fat32/regs.inc \
 	dos/fat32/sdcard.inc \
-	dos/fat32/text_input.inc
+	dos/fat32/text_input.inc \
+	utility/macros.inc
 
 GEOS_DEPS= \
 	$(GENERIC_DEPS) \

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,9 @@ DOS_SOURCES = \
 	dos/functions.s \
 	dos/geos.s
 
+UTILITY_SOURCES = \
+	utility/fdisk.s
+
 GEOS_SOURCES= \
 	geos/kernal/bitmask/bitmask2.s \
 	geos/kernal/conio/conio1.s \
@@ -324,6 +327,14 @@ DOS_DEPS = \
 	dos/functions.inc \
 	dos/vera.inc
 
+UTILITY_DEPS = \
+	$(GENERIC_DEPS) \
+	dos/fat32/fat32.inc \
+	dos/fat32/lib.inc \
+	dos/fat32/regs.inc \
+	dos/fat32/sdcard.inc \
+	dos/fat32/text_input.inc
+
 GEOS_DEPS= \
 	$(GENERIC_DEPS) \
 	geos/config.inc \
@@ -361,6 +372,7 @@ CHARSET_OBJS = $(addprefix $(BUILD_DIR)/, $(CHARSET_SOURCES:.s=.o))
 GRAPH_OBJS   = $(addprefix $(BUILD_DIR)/, $(GRAPH_SOURCES:.s=.o))
 DEMO_OBJS    = $(addprefix $(BUILD_DIR)/, $(DEMO_SOURCES:.s=.o))
 AUDIO_OBJS   = $(addprefix $(BUILD_DIR)/, $(AUDIO_SOURCES:.s=.o))
+UTILITY_OBJS = $(addprefix $(BUILD_DIR)/, $(UTILITY_SOURCES:.s=.o))
 
 ifeq ($(MACHINE),c64)
 	BANK_BINS = $(BUILD_DIR)/kernal.bin
@@ -376,7 +388,8 @@ else
 		$(BUILD_DIR)/codex.bin \
 		$(BUILD_DIR)/graph.bin \
 		$(BUILD_DIR)/demo.bin \
-		$(BUILD_DIR)/audio.bin
+		$(BUILD_DIR)/audio.bin \
+		$(BUILD_DIR)/utility.bin
 endif
 
 ifeq ($(MACHINE),x16)
@@ -468,6 +481,12 @@ $(BUILD_DIR)/audio.bin: $(AUDIO_OBJS) $(AUDIO_DEPS) $(CFG_DIR)/audio-$(MACHINE).
 	$(LD) -C $(CFG_DIR)/audio-$(MACHINE).cfg $(AUDIO_OBJS) -o $@ -m $(BUILD_DIR)/audio.map -Ln $(BUILD_DIR)/audio.sym
 	./scripts/relist.py $(BUILD_DIR)/audio.map $(BUILD_DIR)/audio
 
+# Bank B : utility
+$(BUILD_DIR)/utility.bin: $(UTILITY_OBJS) $(UTILITY_DEPS) $(CFG_DIR)/utility-$(MACHINE).cfg
+	@mkdir -p $$(dirname $@)
+	$(LD) -C $(CFG_DIR)/utility-$(MACHINE).cfg $(UTILITY_OBJS) -o $@ -m $(BUILD_DIR)/utility.map -Ln $(BUILD_DIR)/utility.sym
+	./scripts/relist.py $(BUILD_DIR)/utility.map $(BUILD_DIR)/utility
+
 
 $(BUILD_DIR)/rom_labels.h: $(BANK_BINS)
 	./scripts/symbolize.sh 0 build/x16/kernal.sym   > $@
@@ -478,6 +497,7 @@ $(BUILD_DIR)/rom_labels.h: $(BANK_BINS)
 	./scripts/symbolize.sh 5 build/x16/monitor.sym >> $@
 	./scripts/symbolize.sh 6 build/x16/charset.sym >> $@
 	./scripts/symbolize.sh A build/x16/audio.sym   >> $@
+	./scripts/symbolize.sh B build/x16/utility.sym >> $@
 
 $(BUILD_DIR)/rom_lst.h: $(BANK_BINS)
 	./scripts/trace_lst.py 0 `find build/x16/kernal/ -name \*.rlst` > $@
@@ -486,3 +506,4 @@ $(BUILD_DIR)/rom_lst.h: $(BANK_BINS)
 	./scripts/trace_lst.py 4 `find build/x16/basic/ -name \*.rlst` >> $@
 	./scripts/trace_lst.py 5 `find build/x16/monitor/ -name \*.rlst`   >> $@
 	./scripts/trace_lst.py A `find build/x16/audio/ -name \*.rlst`   >> $@
+	./scripts/trace_lst.py B `find build/x16/utility/ -name \*.rlst`   >> $@

--- a/basic/token2.s
+++ b/basic/token2.s
@@ -112,6 +112,7 @@ reslst3
 	.byt "I2CPOK", 'E' + $80
 	.byt "SLEE", 'P' + $80
 	.byt "BSAV", 'E' + $80
+	.byt "FDIS", 'K' + $80
 	
 	; add new statements before this line
 

--- a/basic/tokens.s
+++ b/basic/tokens.s
@@ -133,6 +133,7 @@ stmdsp2	; statements
 	.word i2cpoke-1
 	.word sleep-1
 	.word cbsave-1
+	.word fdisk-1
 
 	; functions
 ptrfunc	.word vpeek

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -50,6 +50,13 @@ VERA_PALETTE_BASE = $1FA00
 VERA_SPRITES_BASE = $1FC00
 
 ;***************
+fdisk:
+	jsr bjsrfar
+	.word $C000
+	.byte BANK_UTILITY
+	rts
+
+;***************
 monitor:
 	jsr bjsrfar
 	.word $c000

--- a/cfg/dos-x16.cfgtpl
+++ b/cfg/dos-x16.cfgtpl
@@ -12,5 +12,7 @@ SEGMENTS {
 	CODE:         load = DOS,      type = ro;
 	IRQB:         load = IRQB,     type = ro;
 
+
+	DOSCARD:      load = DOSCARD,  type = bss;
 	BSS:          load = DOSDAT,   type = bss;
 }

--- a/cfg/utility-x16.cfgtpl
+++ b/cfg/utility-x16.cfgtpl
@@ -1,0 +1,9 @@
+MEMORY {
+	#include "x16.cfginc"
+
+	UTILITY:      start = $C000, size = $3FFE, fill=yes, fillval=$AA;
+}
+
+SEGMENTS {
+    CODE:        load = UTILITY,    type = ro;
+}

--- a/cfg/utility-x16.cfgtpl
+++ b/cfg/utility-x16.cfgtpl
@@ -1,9 +1,20 @@
 MEMORY {
 	#include "x16.cfginc"
 
-	UTILITY:      start = $C000, size = $3FFE, fill=yes, fillval=$AA;
+	UTILITY: start = $C000, size = $3B00, fill=yes, fillval=$AA;
+	KSUP_CODE11: start = $FB00, size = $03A8, fill=yes, fillval=$AA;
+	KSUP_VEC11:  start = $FEA8, size = $0158, fill=yes, fillval=$AA;
+
 }
 
 SEGMENTS {
-    CODE:        load = UTILITY,    type = ro;
+	ZPKERNAL: load = ZPKERNAL, type = zp;
+	ZPUTIL:   load = ZPUTIL, type = zp;
+	UTILTBL: load = UTILITY, type = ro;
+    CODE: load = UTILITY, type = ro;
+	UTILCMD: load = UTILITY, type = ro, align = $0100;
+	KSUP_CODE11: load = KSUP_CODE11, type = ro;
+	KSUP_VEC11:  load = KSUP_VEC11,  type = ro;
+	DATA: load = UTILITY, type = ro;
+	BSS: load = UTILDAT, type = bss;
 }

--- a/cfg/x16.cfginc
+++ b/cfg/x16.cfginc
@@ -15,7 +15,8 @@
 /*        start = $0000, size = $0080; # available to the user (or GEOS) */
 ZPKERNAL: start = $0080, size = $0010; # KERNAL
 ZPDOS:    start = $0090, size = $000B; # DOS
-/*        start = $009B, size = $000C; # reserved for DOS or BASIC growth */
+/*        start = $009B, size = $000A; # reserved for DOS or BASIC growth */
+ZPUTIL:   start = $00A5, size = $0002; # UTILITY
 ZPAUDIO:  start = $00A7, size = $0002; # AUDIO
 ZPMATH:   start = $00A9, size = $002B; # MATH
 ZPBASIC:  start = $00D4, size = $002B; # BASIC (last byte used: $FE)
@@ -43,5 +44,7 @@ KVARSB0:  start = $A800, size = $0500; # there is some space free here
 BVARSB0:  start = $AD00, size = $00C0; # BASIC expansion variables, few used
 AUDIOBSS: start = $ADC0, size = $0040; # audio bank scratch space and misc state
 BAUDIO:   start = $AE00, size = $0100; # YM2151 shadow for audio routines
-DOSDAT:   start = $B000, size = $0F00; # there is some space free here, too
+DOSCARD:  start = $B000, size = $0207; # SD card
+DOSDAT:   start = $B207, size = $09F9; # FAT32
 USERPARM: start = $BF00, size = $0100; # Reserved param passing area for user progs
+UTILDAT:  start = $BC00, size = $0400; # utility data

--- a/dos/fat32/sdcard.s
+++ b/dos/fat32/sdcard.s
@@ -7,8 +7,9 @@
 	.include "sdcard.inc"
 
 	.export sector_buffer, sector_buffer_end, sector_lba
+	.export select, deselect, spi_read, spi_write, send_cmd, sdcard_read_sector, sdcard_write_sector
 
-	.bss
+	.segment "DOSCARD"
 cmd_idx = sdcard_param
 cmd_arg = sdcard_param + 1
 cmd_crc = sdcard_param + 5

--- a/dos/jumptab.s
+++ b/dos/jumptab.s
@@ -9,6 +9,8 @@
 
 .import dos_init, dos_set_time
 
+.import select, deselect, spi_read, spi_write, send_cmd, sdcard_read_sector, sdcard_write_sector, sdcard_check
+
 .segment "dos_jmptab"
 ; $C000
 
@@ -36,3 +38,13 @@
 	jmp dos_set_time          ; 16
 
 	jmp dos_macptr            ; 17
+
+; SD card
+	jmp select                ; 18
+	jmp deselect              ; 19
+	jmp spi_read              ; 20
+	jmp spi_write             ; 21
+	jmp send_cmd              ; 22
+	jmp sdcard_read_sector    ; 23
+	jmp sdcard_write_sector   ; 24
+	jmp sdcard_check          ; 25

--- a/dos/main.s
+++ b/dos/main.s
@@ -35,6 +35,7 @@
 ; jumptab.s
 .export dos_secnd, dos_tksa, dos_acptr, dos_ciout, dos_untlk, dos_unlsn, dos_listn, dos_talk, dos_macptr
 .export dos_set_time
+.export sdcard_check
 
 .include "banks.inc"
 

--- a/inc/banks.inc
+++ b/inc/banks.inc
@@ -10,6 +10,7 @@ BANK_CODEX   = $07
 BANK_GRAPH   = $08
 BANK_DEMO    = $09
 BANK_AUDIO   = $0A
+BANK_UTILITY = $0B
 
 ; XXX these constant RAM addresses are KERNAL
 ; XXX implementation details and need to go away!

--- a/kernsup/kernsup_utility.s
+++ b/kernsup/kernsup_utility.s
@@ -1,0 +1,41 @@
+.include "banks.inc"
+
+.import bjsrfar
+
+.macro bridge symbol
+	.local address
+	.segment "KSUP_VEC11"
+address = *
+	.segment "KSUP_CODE11"
+symbol:
+	jsr ujsrfar
+	.word address
+	.byte BANK_KERNAL
+	rts
+	.segment "KSUP_VEC11"
+	jmp symbol
+.endmacro
+
+.setcpu "65c02"
+
+.segment "KSUP_CODE11"
+
+; Utility bank's entry into jsrfar
+.setcpu "65c02"
+    ram_bank = 0
+    rom_bank = 1
+.export ujsrfar
+ujsrfar:
+.include "jsrfar.inc"
+
+
+.segment "KSUP_VEC11"
+
+    xjsrfar = ujsrfar
+.include "kernsup.inc"
+
+    .byte 0, 0, 0, 0 ; signature
+
+    .word $ffff ; nmi
+    .word $ffff ; reset
+    .word banked_irq

--- a/utility/commands.s
+++ b/utility/commands.s
@@ -50,6 +50,7 @@ fdisk_commands:
 	.word 0 ; 'z'
 
 fdisk_categories:
+	.word category_dos
 	.word category_generic
 	.word category_misc
 	.word category_save
@@ -57,6 +58,12 @@ fdisk_categories:
 	.word 0
 
 .data
+category_dos:
+	.asciiz "DOS (MBR)"
+	.byte 'a'
+	.asciiz "toggle a bootable flag"
+	.byte $00
+
 category_generic:
 	.asciiz "Generic"
 	.byte 'n'

--- a/utility/commands.s
+++ b/utility/commands.s
@@ -7,13 +7,22 @@
 
 .export fdisk_commands
 
-.import command_loop_exit, read_mbr_sector, write_mbr_sector, create_empty_mbr, print_u8_hex
-.import putstr
+.import command_loop_exit, read_mbr_sector, write_mbr_sector, create_empty_mbr, print_u32_hex, print_u8_hex, parse_u32_hex, parse_u8_hex, read_character, read_line
+.import putstr, line_buffer, sector_size
 .importzp putstr_ptr, tmp2, util_tmp
+
+.bss
+
+new_partition_first_sector:
+new_partition_first_sector_minimum:
+	.res 4
+new_partition_last_sector_minimum: .res 4
+new_partition_last_sector_maximum: .res 4
+new_partition_sector_input = line_buffer+255-4
 
 .segment "UTILCMD"
 fdisk_commands:
-	.word 0 ; 'a'
+	.word set_bootable-1 ; 'a'
 	.word 0 ; 'b'
 	.word 0 ; 'c'
 	.word 0 ; 'd'
@@ -26,7 +35,7 @@ fdisk_commands:
 	.word 0 ; 'k'
 	.word 0 ; 'l'
 	.word help-1 ; 'm'
-	.word 0 ; 'n'
+	.word new_partition-1 ; 'n'
 	.word create_empty_mbr-1 ; 'o'
 	.word partition_info-1 ; 'p'
 	.word quit-1 ; 'q'
@@ -78,8 +87,197 @@ category_label:
 
 .code
 
+; A, r1L: check for used (00 == free, otherwise used)
+; r1L: mask
+; r1H: first partition
+; r2L, A: selected partition
+; C = error
+.proc select_partition
+	sta r1L
+	stz r1H
+	ldx #00
+
+find_matching:
+	jsr check_partition
+	bcs :+
+
+	ldy r1H
+	bne :+
+	stx r1H
+
+:	inx
+	cpx #04
+	bne find_matching
+
+	lda r1H
+	bne print_loop
+
+none:
+	lda r1L
+	beq @used
+
+	lda #<(select_used_partition_no_free_partition)
+	ldy #>(select_used_partition_no_free_partition)
+	bra :+
+
+@used:
+	lda #<(select_used_partition_no_used_partition)
+	ldy #>(select_used_partition_no_used_partition)
+
+:	sta putstr_ptr
+	sty putstr_ptr + 1
+	jsr putstr
+	sec
+	rts
+
+print_loop:
+	print new_partition_number_1
+
+	ldx r1H
+:	jsr check_partition
+	bcs :+
+
+	txa
+	ina
+
+	phx
+	jsr print_u8_hex
+	plx
+
+	printc ','
+	printc ' '
+
+:	inx
+	cpx #04
+	bne :--
+
+	print new_partition_number_2
+	lda r1H
+	ina
+	jsr print_u8_hex
+
+	print new_partition_number_3
+
+	jsr read_line
+	bvs @exit
+	cpx #00
+	bne :+
+
+	lda r1H
+	clc
+	rts
+
+:	ldx #00
+	jsr parse_u8_hex
+	bcs @error
+
+	cmp #05
+	bcs @error
+
+	sbc #00
+
+	sta r2L
+
+:	ldx r1H
+	jsr check_partition
+	bcs :+
+
+	cpx r2L
+	beq @success
+:	cpx #3
+	beq @error
+	inx
+	bra :--
+
+@error:
+	clc
+	print new_partition_out_of_range
+	jmp print_loop
+
+@success:
+	lda r2L
+	clc
+@exit:
+	rts
+
+.proc check_partition
+	jsr load_partition_table_entry
+	ldy #partition_table_entry::partition_type
+	lda r1L
+	bne check_for_used
+	lda (r0),y
+	beq success
+	bra failure
+
+check_for_used:
+	lda (r0),y
+	bne success
+	bra failure
+
+success:
+	clc
+	rts
+
+failure:
+	sec
+	rts
+.endproc
+.endproc
+
+.proc is_extended
+	cmp #$05
+	beq :+
+	cmp #$0F
+:	rts
+.endproc
+
+.proc set_bootable
+	lda #$FF
+	jsr select_partition
+	bvs end
+	bcs end
+
+	tax
+	ina
+	sta r1L
+
+	jsr load_partition_table_entry
+	ldy #partition_table_entry::partition_type
+	lda (r0),y
+	jsr is_extended
+	bne :+
+
+	print set_bootable_extended_1
+
+	lda r1L
+	jsr print_u8_hex
+
+	print set_bootable_extended_2
+
+:	print set_bootable_success_1
+	lda r1L
+	jsr print_u8_hex
+
+	print set_bootable_success_2
+
+	ldy #partition_table_entry::bootable
+	lda (r0),y
+	bne :+
+	lda #$80
+	sta (r0),y
+	print set_bootable_success_3_enabled
+	bra end
+:	lda #00
+	sta (r0),y
+	print set_bootable_success_3_disabled
+
+end:
+	print set_bootable_success_4
+	rts
+.endproc
+
 ; *********************************************************************
-; * Display all commands 
+; * Display all commands
 ; *********************************************************************
 
 .proc help
@@ -148,6 +346,410 @@ end:
 .endproc
 .endproc
 
+; r2L: primary partition counter, selected partition number
+; r2H: extended partition counter, sector count or last sector
+; r3L: free partition counter
+; r3H: first free partition
+; r4L: partition type
+.proc new_partition
+	stz r2L
+	stz r2H
+	stz r3L
+	ldx #03
+
+:	jsr load_partition_table_entry
+	ldy #partition_table_entry::partition_type
+	lda (r0),y
+	bne used
+	inc r3L
+	stx r3H
+	bra :+
+
+used:
+	cmp #$05 ; extended
+	beq extended
+
+	inc r2L
+	bra :+
+extended:
+	inc r2H
+
+:	cpx #00
+	beq check_free_space
+	dex
+	bra :--
+
+check_free_space:
+	lda r3L
+	bne :+
+
+	print new_partition_no_free_partition
+	rts
+
+:	print new_partition_type_1
+
+partition_type_loop:
+	print new_partition_type_2
+	lda r2L
+	jsr print_u8_hex
+
+	print new_partition_type_3
+	lda r2H
+	jsr print_u8_hex
+
+	print new_partition_type_4
+	lda r3L
+	jsr print_u8_hex
+
+	print new_partition_type_5
+
+	jsr read_character
+	bvc :+
+	rts
+:	beq @default
+
+	cmp #'p'
+	beq @primary
+
+	cmp #'e'
+	beq @extended
+
+	print new_partition_out_of_range
+	bra partition_type_loop
+
+@default:
+	print new_partition_type_default
+
+@primary:
+	lda #new_partition_type_primary
+	bra :+
+
+@extended:
+	lda #new_partition_type_extended
+
+:	sta r4L
+
+partition_number_loop:
+	lda #00
+	jsr select_partition
+	bvc :+
+	rts
+:	sta r2L
+
+first_sector_minimum:
+	bne :+
+	set32_val new_partition_first_sector_minimum, 1
+	bra last_sector_maximum
+
+: 	dea
+	tax
+	jsr load_partition_table_entry
+	lda #partition_table_entry::first_sector_lba
+	clc
+	adc r0L
+	sta r0L
+	lda #00
+	adc r0H
+	sta r0H
+
+	ldy #3
+:	lda (r0),y
+	sta new_partition_first_sector_minimum,y
+	dey
+	bpl :-
+
+	lda #4
+	clc
+	adc r0L
+	lda #00
+	adc r0H
+
+	ldy #3
+:	lda (r0),y
+	clc
+	adc new_partition_first_sector_minimum,y
+	sta new_partition_first_sector_minimum,y
+	dey
+	bpl :-
+
+last_sector_maximum:
+	ldx r2L
+	cpx #3
+	bne :+
+	set32 last_sector_maximum, sector_size
+	bra first_sector
+
+:	inx
+	ldy #partition_table_entry::partition_type
+:	jsr load_partition_table_entry
+	lda (r0),y
+	bne :+
+	cpx #03
+	beq @end
+	inx
+	bne :-
+
+@end:
+	set32 new_partition_last_sector_maximum, sector_size
+	bra first_sector
+
+:	ldy #partition_table_entry::first_sector_lba+3
+:	lda (r0),y
+	sta new_partition_last_sector_maximum,y
+	dey
+	bpl :-
+
+	sub32_val new_partition_last_sector_maximum, new_partition_last_sector_maximum, 1
+
+first_sector:
+	print new_partition_first_sector_1
+
+	set16_val r0, new_partition_first_sector_minimum
+	jsr print_u32_hex
+
+	printc '-'
+
+	set16_val r0, new_partition_last_sector_maximum
+	jsr print_u32_hex
+
+	print new_partition_first_sector_2
+	set16_val r0, new_partition_first_sector_minimum
+	jsr print_u32_hex
+
+	print new_partition_first_sector_3
+
+	jsr read_line
+	bvc :+
+	rts
+:	cpx #00
+	beq @default
+
+	ldx #00
+	set16_val r0, new_partition_sector_input
+	jsr parse_u32_hex
+	bcs @error
+
+@compare_to_minimum:
+	ldy #03
+:	lda (r0),y
+	cmp new_partition_first_sector_minimum,y
+	bcc @error
+	beq :+
+	bcs @compare_to_maximum
+:	dey
+	bpl :--
+
+@compare_to_maximum:
+	ldy #03
+:	lda (r0),y
+	cmp new_partition_last_sector_maximum,y
+	bcc @success
+	beq :+
+	bcs @error
+:	dey
+	bpl :--
+
+@error:
+	clc
+	print new_partition_out_of_range
+	jmp first_sector
+
+
+@success:
+	set32 new_partition_first_sector_minimum, new_partition_sector_input
+@default:
+	clc
+	lda new_partition_first_sector_minimum
+	adc #01
+	sta new_partition_last_sector_minimum
+
+	lda new_partition_first_sector_minimum + 1
+	adc #00
+	sta new_partition_last_sector_minimum + 1
+
+	lda new_partition_first_sector_minimum + 2
+	adc #00
+	sta new_partition_last_sector_minimum + 2
+
+	lda new_partition_first_sector_minimum + 3
+	adc #00
+	sta new_partition_last_sector_minimum + 3
+
+sector_count:
+	print new_partition_sector_count_1
+
+	set16_val r0, new_partition_last_sector_minimum
+	jsr print_u32_hex
+
+	printc '-'
+
+	set16_val r0, new_partition_last_sector_maximum
+	jsr print_u32_hex
+
+	print new_partition_sector_count_2
+	set16_val r0, new_partition_last_sector_minimum
+	jsr print_u32_hex
+
+	print new_partition_sector_count_3
+
+	jsr read_line
+	bvc :+
+	rts
+:	cpx #00
+	bne :+
+	jmp @default ; Cannot use bra, out of range
+
+:	lda line_buffer ; sector count?
+	cmp #'+'
+	bne :+
+	lda #01
+	bra :++
+
+:	lda #00
+
+:	sta r2H
+	tax
+	set16_val r0, new_partition_sector_input
+	jsr parse_u32_hex
+	bcs @error
+
+	lda r2H
+	beq @compare_to_minimum
+	add32 new_partition_sector_input, new_partition_last_sector_minimum, new_partition_sector_input
+
+@compare_to_minimum: ; FIXME: Deduplicate
+	ldy #03
+:	lda (r0),y
+	cmp new_partition_last_sector_minimum,y
+	bcc @error
+	beq :+
+	bcs @compare_to_maximum
+:	dey
+	bpl :--
+
+@compare_to_maximum:
+	ldy #03
+:	lda (r0),y
+	cmp new_partition_last_sector_maximum,y
+	bcc @success
+	beq :+
+	bcs @error
+:	dey
+	bpl :--
+
+@error:
+	clc
+	print new_partition_out_of_range
+	jmp sector_count
+
+@success:
+	sub32 new_partition_last_sector_maximum, new_partition_sector_input, new_partition_first_sector_minimum
+	add32_val new_partition_last_sector_maximum, new_partition_last_sector_maximum, 1
+@default:
+
+	lda r2L
+	tax
+	jsr load_partition_table_entry
+
+	ldy #partition_table_entry::partition_type
+	lda r4L
+	sta (r0),y
+
+	ldx #3
+	ldy #partition_table_entry::first_sector_lba + 3
+
+:	lda new_partition_first_sector_minimum,x
+	sta (r0),y
+	dey
+	dex
+	bpl :-
+
+	ldx #3
+	ldy #partition_table_entry::sector_count + 3
+
+:	lda new_partition_last_sector_maximum,x
+	sta (r0),y
+	dey
+	dex
+	bpl :-
+
+	lda #00
+	ldy #partition_table_entry::bootable
+	sta (r0),y
+
+	ldy #partition_table_entry::first_sector_chs
+	sta (r0),y
+	iny
+	sta (r0),y
+	iny
+	sta (r0),y
+
+	ldy #partition_table_entry::last_sector_chs
+	sta (r0),y
+	iny
+	sta (r0),y
+	iny
+	sta (r0),y
+
+	print new_partition_created_1
+	lda r2L
+	ina
+	jsr print_u8_hex
+
+	print new_partition_created_2
+
+	ldx #00
+:   lda partition_types,x
+	beq @no_type
+	inx
+	cmp r4L
+	beq :+
+	inx
+	inx
+	bra :-
+
+:   lda partition_types,x
+	sta putstr_ptr
+	lda partition_types + 1,x
+	sta putstr_ptr + 1
+
+	jsr putstr
+
+	bra @size
+
+@no_type:
+	lda r4L
+	jsr print_u8_hex
+
+@size:
+	print new_partition_created_3
+
+	set16_val r0, new_partition_last_sector_maximum
+	jsr print_u32_hex
+
+	print new_partition_created_4
+
+	rts
+.endproc
+
+.proc load_partition_table_entry ; X: index, r0: partition table
+	txa
+	asl
+	asl
+	asl
+	asl
+	sta r0L
+
+	clc
+	lda #<(sector_buffer + mbr::partition_table)
+	adc r0L
+	sta r0L
+	lda #>(sector_buffer + mbr::partition_table)
+	adc #00
+	sta r0H
+	rts
+.endproc
+
 .proc partition_info
 	print partition_info_1
 	printc '8'
@@ -203,20 +805,7 @@ end:
 	rts
 
 .proc print_partition ; X: counter, r0: partition table, r1L: tmp
-	txa
-	asl
-	asl
-	asl
-	asl
-	sta r1L
-
-	clc
-	lda #<(sector_buffer + mbr::partition_table)
-	adc r1L
-	sta r0L
-	lda #>(sector_buffer + mbr::partition_table)
-	adc #00
-	sta r0H
+	jsr load_partition_table_entry
 
 	ldy #partition_table_entry::partition_type
 	lda (r0),y
@@ -320,6 +909,92 @@ three_spaces_with_newline:
 
 two_spaces_with_newline:
 	.byte $0A, $0D, $0A, $0D, ' ', ' ', $00
+
+select_used_partition_no_used_partition:
+	.byte $1C, "No partition is defined yet!", $05, $0A, $0D, $00
+
+select_used_partition_no_free_partition:
+	.byte $1C, "All space for primary partitions is in use.", $05, $0A, $0D, $00
+
+set_bootable_extended_1:
+	.byte $1C, "Partition "
+
+set_bootable_extended_2:
+	.byte "is an extended partition.", $05, $0A, $0D, $00
+
+set_bootable_success_1:
+	.asciiz "The bootable flag on partition "
+
+set_bootable_success_2:
+	.asciiz " is "
+
+set_bootable_success_3_enabled:
+	.asciiz "enabled"
+
+set_bootable_success_3_disabled:
+	.asciiz "disabled"
+
+set_bootable_success_4:
+	.byte " now.", $0A, $0D, $00
+
+new_partition_no_free_partition:
+	.byte "To create more partitions, first replace a primary with an extended partition.", $0A, $0D, $00
+
+new_partition_type_1:
+	.asciiz "Partition type"
+
+new_partition_type_2:
+	.byte $0A, $0D, "   p  primary (", $00
+
+new_partition_type_3:
+	.asciiz " primary, "
+
+new_partition_type_4:
+	.asciiz " extended, "
+
+new_partition_type_5:
+	.byte " free)", $0A, $0D, "   e  extended (container for logical partitions)", $0A, $0D, "Select (default p): ", $00
+
+new_partition_out_of_range:
+	.byte $1C, "Value type out of range.", $05, $0A, $0D, $00
+
+new_partition_type_default:
+	.byte "Using default response p.", $0A, $0D, $00
+
+new_partition_type_primary = $0C ; FAT32
+new_partition_type_extended = $05
+
+new_partition_number_1:
+	.asciiz "Partition number ("
+
+new_partition_first_sector_2:
+new_partition_sector_count_2:
+	.byte ", "
+new_partition_number_2:
+	.asciiz "default "
+
+new_partition_number_3:
+new_partition_first_sector_3:
+new_partition_sector_count_3:
+	.byte "): ", $00
+
+new_partition_first_sector_1:
+	.asciiz "First sector ("
+
+new_partition_sector_count_1:
+	.asciiz "Last sector or sectors ("
+
+new_partition_created_1:
+	.asciiz "Created partition "
+
+new_partition_created_2:
+	.asciiz " of type "
+
+new_partition_created_3:
+	.asciiz " and of size "
+
+new_partition_created_4:
+	.byte " sectors.", $0A, $0D, $00
 
 partition_info_1:
 	.byte $01

--- a/utility/commands.s
+++ b/utility/commands.s
@@ -94,15 +94,16 @@ category_label:
 ; C = error
 .proc select_partition
 	sta r1L
-	stz r1H
+	lda #$FF
+	sta r1H
 	ldx #00
 
 find_matching:
 	jsr check_partition
 	bcs :+
 
-	ldy r1H
-	bne :+
+	lda r1H
+	bpl :+
 	stx r1H
 
 :	inx
@@ -110,7 +111,7 @@ find_matching:
 	bne find_matching
 
 	lda r1H
-	bne print_loop
+	bpl print_loop
 
 none:
 	lda r1L

--- a/utility/commands.s
+++ b/utility/commands.s
@@ -186,8 +186,8 @@ print_loop:
 
 	sta r2L
 
-:	ldx r1H
-	jsr check_partition
+	ldx r1H
+:	jsr check_partition
 	bcs :+
 
 	cpx r2L

--- a/utility/commands.s
+++ b/utility/commands.s
@@ -1012,7 +1012,7 @@ error:
 	jsr write_mbr_sector
 	bcc :+
 	print write_success
-	jmp quit
+	rts
 :   print write_error
 	rts
 .endproc

--- a/utility/commands.s
+++ b/utility/commands.s
@@ -1033,25 +1033,25 @@ help_text:
 	.asciiz "Help:"
 
 three_spaces_with_newline:
-	.byte $0A, $0D, ' ', ' ', ' ', $00
+	.byte $0D, ' ', ' ', ' ', $00
 
 two_spaces_with_newline:
-	.byte $0A, $0D, $0A, $0D, ' ', ' ', $00
+	.byte $0D, $0D, ' ', ' ', $00
 
 value_out_of_range:
-	.byte $1C, "Value type out of range.", $05, $0A, $0D, $00
+	.byte $1C, "Value type out of range.", $05, $0D, $00
 
 select_used_partition_no_used_partition:
-	.byte $1C, "No partition is defined yet!", $05, $0A, $0D, $00
+	.byte $1C, "No partition is defined yet!", $05, $0D, $00
 
 select_used_partition_no_free_partition:
-	.byte $1C, "All space for primary partitions is in use.", $05, $0A, $0D, $00
+	.byte $1C, "All space for primary partitions is in use.", $05, $0D, $00
 
 set_bootable_extended_1:
 	.byte $1C, "Partition "
 
 set_bootable_extended_2:
-	.byte "is an extended partition.", $05, $0A, $0D, $00
+	.byte "is an extended partition.", $05, $0D, $00
 
 set_bootable_success_1:
 	.asciiz "The bootable flag on partition "
@@ -1066,19 +1066,19 @@ set_bootable_success_3_disabled:
 	.asciiz "disabled"
 
 set_bootable_success_4:
-	.byte " now.", $0A, $0D, $00
+	.byte " now.", $0D, $00
 
 delete_partition_2:
-	.byte " has been deleted.", $0A, $0D, $00
+	.byte " has been deleted.", $0D, $00
 
 new_partition_no_free_partition:
-	.byte "To create more partitions, first replace a primary with an extended partition.", $0A, $0D, $00
+	.byte "To create more partitions, first replace a primary with an extended partition.", $0D, $00
 
 new_partition_type_1:
 	.asciiz "Partition type"
 
 new_partition_type_2:
-	.byte $0A, $0D, "   p  primary (", $00
+	.byte $0D, "   p  primary (", $00
 
 new_partition_type_3:
 	.asciiz " primary, "
@@ -1087,10 +1087,10 @@ new_partition_type_4:
 	.asciiz " extended, "
 
 new_partition_type_5:
-	.byte " free)", $0A, $0D, "   e  extended (container for logical partitions)", $0A, $0D, "Select (default p): ", $00
+	.byte " free)", $0D, "   e  extended (container for logical partitions)", $0D, "Select (default p): ", $00
 
 new_partition_type_default:
-	.byte "Using default response p.", $0A, $0D, $00
+	.byte "Using default response p.", $0D, $00
 
 new_partition_type_primary = $0C ; FAT32
 new_partition_type_extended = $05
@@ -1125,7 +1125,7 @@ new_partition_created_3:
 	.asciiz " and of size "
 
 new_partition_created_4:
-	.byte " sectors.", $0A, $0D, $00
+	.byte " sectors.", $0D, $00
 
 partition_info_1:
 	.byte $01
@@ -1141,7 +1141,7 @@ partition_info_4:
 	.asciiz " bytes, "
 
 partition_info_5:
-	.byte " sectors", $01, $0A, $0D
+	.byte " sectors", $01, $0D
 	.asciiz "Units: sectors of "
 
 partition_info_6:
@@ -1151,20 +1151,20 @@ partition_info_7:
 	.asciiz " = "
 
 partition_info_8:
-	.byte " bytes", $0A, $0D, "Sector size (logical/physical): ", $00
+	.byte " bytes", $0D, "Sector size (logical/physical): ", $00
 
 partition_info_9:
 partition_info_11:
 	.asciiz " bytes / "
 
 partition_info_10:
-	.byte " bytes", $0A, $0D, "I/O size (minimum/optimal): ", $00
+	.byte " bytes", $0D, "I/O size (minimum/optimal): ", $00
 
 partition_info_12:
-	.byte " bytes", $0A, $0D, "Disk identifier: 0x", $00
+	.byte " bytes", $0D, "Disk identifier: 0x", $00
 
 partition_info_13:
-	.byte $0A, $0D, $0A, $0D, $01
+	.byte $0D, $0D, $01
 delete_partition_1:
 	.asciiz "Partition "
 
@@ -1178,13 +1178,13 @@ partition_info_bootable_no:
 	.asciiz "no"
 
 partition_info_15:
-	.byte $0A, $0D, "First sector LBA: ", $00
+	.byte $0D, "First sector LBA: ", $00
 
 partition_info_16:
-	.byte $0A, $0D, "Sector count: ", $00
+	.byte $0D, "Sector count: ", $00
 
 partition_info_17:
-	.byte $0A, $0D, "Partition type: ", $00
+	.byte $0D, "Partition type: ", $00
 
 partition_info_18:
 list_partition_types_1:
@@ -1226,7 +1226,7 @@ change_type_4:
 	.asciiz "'."
 
 write_success:
-	.byte "The partition table has been altered.", $0A, $0D, "Syncing disks.", $0A, $0D, $00
+	.byte "The partition table has been altered.", $0D, "Syncing disks.", $0D, $00
 
 write_error:
 	.asciiz "Error writing partition table to disk."

--- a/utility/commands.s
+++ b/utility/commands.s
@@ -238,6 +238,31 @@ failure:
 :	rts
 .endproc
 
+; r1L: type
+.proc print_partition_type
+	sta r1L
+	ldx #00
+:   lda partition_types,x
+	beq no_type
+	inx
+	cmp r1L
+	beq :+
+	inx
+	inx
+	bra :-
+
+:   lda partition_types,x
+	sta putstr_ptr
+	lda partition_types + 1,x
+	sta putstr_ptr + 1
+
+	jmp putstr
+
+no_type:
+	lda r1L
+	jmp print_u8_hex
+.endproc
+
 .proc set_bootable
 	lda #$FF
 	jsr select_partition
@@ -703,30 +728,9 @@ sector_count:
 
 	print new_partition_created_2
 
-	ldx #00
-:   lda partition_types,x
-	beq @no_type
-	inx
-	cmp r4L
-	beq :+
-	inx
-	inx
-	bra :-
-
-:   lda partition_types,x
-	sta putstr_ptr
-	lda partition_types + 1,x
-	sta putstr_ptr + 1
-
-	jsr putstr
-
-	bra @size
-
-@no_type:
 	lda r4L
-	jsr print_u8_hex
+	jsr print_partition_type
 
-@size:
 	print new_partition_created_3
 
 	set16_val r0, new_partition_last_sector_maximum

--- a/utility/commands.s
+++ b/utility/commands.s
@@ -1,0 +1,411 @@
+.include "banks.inc"
+.include "kernal.inc"
+.include "macros.inc"
+.include "regs.inc"
+
+.include "../dos/fat32/lib.inc"
+
+.export fdisk_commands
+
+.import command_loop_exit, read_mbr_sector, write_mbr_sector, create_empty_mbr, print_u8_hex
+.import putstr
+.importzp putstr_ptr, tmp2, util_tmp
+
+.segment "UTILCMD"
+fdisk_commands:
+	.word 0 ; 'a'
+	.word 0 ; 'b'
+	.word 0 ; 'c'
+	.word 0 ; 'd'
+	.word 0 ; 'e'
+	.word 0 ; 'f'
+	.word 0 ; 'g'
+	.word 0 ; 'h'
+	.word 0 ; 'i'
+	.word 0 ; 'j'
+	.word 0 ; 'k'
+	.word 0 ; 'l'
+	.word help-1 ; 'm'
+	.word 0 ; 'n'
+	.word create_empty_mbr-1 ; 'o'
+	.word partition_info-1 ; 'p'
+	.word quit-1 ; 'q'
+	.word 0 ; 'r'
+	.word 0 ; 's'
+	.word 0 ; 't'
+	.word 0 ; 'u'
+	.word 0 ; 'v'
+	.word write-1 ; 'w'
+	.word 0 ; 'x'
+	.word 0 ; 'y'
+	.word 0 ; 'z'
+
+fdisk_categories:
+	.word category_generic
+	.word category_misc
+	.word category_save
+	.word category_label
+	.word 0
+
+.data
+category_generic:
+	.asciiz "Generic"
+	.byte 'n'
+	.asciiz "add a new partition"
+	.byte 'p'
+	.asciiz "print the partition table"
+	.byte $00
+
+category_misc:
+	.asciiz "Misc"
+	.byte 'm'
+	.asciiz "print this menu"
+	.byte $00
+
+category_save:
+	.asciiz "Save and Exit"
+	.byte 'w'
+	.asciiz "write table to disk and exit"
+	.byte 'q'
+	.asciiz "quit without saving changes"
+	.byte $00
+
+category_label:
+	.asciiz "Create a new label"
+	.byte 'o'
+	.asciiz "create a new empty DOS partition table"
+	.byte $00
+
+.code
+
+; *********************************************************************
+; * Display all commands 
+; *********************************************************************
+
+.proc help
+	print help_text
+
+	ldy #00
+category_loop:
+	lda fdisk_categories,y
+	beq end
+	sta util_tmp
+	iny
+	lda fdisk_categories,y
+	sta util_tmp+1
+
+	phy
+	jsr print_category
+	ply
+
+	iny
+	bra category_loop
+
+end:
+	rts
+
+.proc print_category
+	print two_spaces_with_newline
+
+	printc $99
+
+	ldy #$FF
+
+print_name:
+	iny
+	lda (util_tmp),y
+	beq :+
+	jsr bsout
+	bra print_name
+
+:   printc $05
+
+command_loop:
+	phy
+	print three_spaces_with_newline
+	ply
+
+	iny
+
+	lda (util_tmp),y
+	beq end
+	jsr bsout
+	iny
+
+	lda #' '
+	jsr bsout
+	jsr bsout
+
+print_description:
+	lda (util_tmp),y
+	beq command_loop
+	iny
+	jsr bsout
+	bra print_description
+
+end:
+	rts
+.endproc
+.endproc
+
+.proc partition_info
+	print partition_info_1
+	printc '8'
+
+	print partition_info_2
+	printc '0'
+
+	print partition_info_3
+	printc '0'
+
+	print partition_info_4
+	printc '0'
+
+	print partition_info_5
+	printc '0'
+
+	print partition_info_6
+	printc '0'
+
+	print partition_info_7
+	printc '0'
+
+	print partition_info_8
+	printc '0'
+
+	print partition_info_9
+	printc '0'
+
+	print partition_info_10
+	printc '0'
+
+	print partition_info_11
+	printc '0'
+
+	print partition_info_12
+	lda sector_buffer + mbr::disk_signature + 3
+	jsr print_u8_hex
+	lda sector_buffer + mbr::disk_signature + 2
+	jsr print_u8_hex
+	lda sector_buffer + mbr::disk_signature + 1
+	jsr print_u8_hex
+	lda sector_buffer + mbr::disk_signature
+	jsr print_u8_hex
+
+	ldx #00
+:   phx
+	jsr print_partition
+	plx
+	inx
+	cpx #4
+	bne :-
+
+	rts
+
+.proc print_partition ; X: counter, r0: partition table, r1L: tmp
+	txa
+	asl
+	asl
+	asl
+	asl
+	sta r1L
+
+	clc
+	lda #<(sector_buffer + mbr::partition_table)
+	adc r1L
+	sta r0L
+	lda #>(sector_buffer + mbr::partition_table)
+	adc #00
+	sta r0H
+
+	ldy #partition_table_entry::partition_type
+	lda (r0),y
+	bne :+
+	rts
+
+:   sta r1L
+
+	print partition_info_13
+	txa
+	clc
+	adc #01
+	jsr print_u8_hex
+
+	print partition_info_14
+	ldy #partition_table_entry::bootable
+	lda (r0),y
+	cmp #$80
+	bne :+
+	print partition_info_bootable_yes
+	bra :++
+:   print partition_info_bootable_no
+
+:   print partition_info_15
+	ldy #partition_table_entry::first_sector_lba + 4
+
+:   dey
+	lda (r0),y
+	phy
+	jsr print_u8_hex
+	ply
+	cpy #partition_table_entry::first_sector_lba
+	bne :-
+
+	print partition_info_16
+	ldy #partition_table_entry::sector_count + 4
+
+:   dey
+	lda (r0),y
+	phy
+	jsr print_u8_hex
+	ply
+	cpy #partition_table_entry::sector_count
+	bne :-
+
+	print partition_info_17
+	lda r1L
+	jsr print_u8_hex
+
+	ldx #00
+:   lda partition_types,x
+	beq end
+	inx
+	cmp r1L
+	beq :+
+	inx
+	inx
+	bra :-
+
+:   phx
+	print partition_info_18
+	plx
+
+	lda partition_types,x
+	sta putstr_ptr
+	lda partition_types + 1,x
+	sta putstr_ptr + 1
+
+	jsr putstr
+end:
+	rts
+.endproc
+.endproc
+
+.proc write
+	jsr write_mbr_sector
+	bcc :+
+	print write_success
+	jmp quit
+:   print write_error
+	rts
+.endproc
+
+.proc quit
+	pla
+	pla
+	lda #>(command_loop_exit)
+	pha
+	lda #<(command_loop_exit)-1
+	pha
+	rts
+.endproc
+
+.data
+
+help_text:
+	.asciiz "Help:"
+
+three_spaces_with_newline:
+	.byte $0A, $0D, ' ', ' ', ' ', $00
+
+two_spaces_with_newline:
+	.byte $0A, $0D, $0A, $0D, ' ', ' ', $00
+
+partition_info_1:
+	.byte $01
+	.asciiz "Disk "
+
+partition_info_2:
+	.asciiz ": "
+
+partition_info_3:
+	.asciiz " B, "
+
+partition_info_4:
+	.asciiz " bytes, "
+
+partition_info_5:
+	.byte " sectors", $01, $0A, $0D
+	.asciiz "Units: sectors of "
+
+partition_info_6:
+	.asciiz " * "
+
+partition_info_7:
+	.asciiz " = "
+
+partition_info_8:
+	.byte " bytes", $0A, $0D, "Sector size (logical/physical): ", $00
+
+partition_info_9:
+partition_info_11:
+	.asciiz " bytes / "
+
+partition_info_10:
+	.byte " bytes", $0A, $0D, "I/O size (minimum/optimal): ", $00
+
+partition_info_12:
+	.byte " bytes", $0A, $0D, "Disk identifier: 0x", $00
+
+partition_info_13:
+	.byte $0A, $0D, $0A, $0D, $01, "Partition ", $00
+
+partition_info_14:
+	.byte $01, $0D, $0A, "Bootable: ", $00
+
+partition_info_bootable_yes:
+	.asciiz "yes"
+
+partition_info_bootable_no:
+	.asciiz "no"
+
+partition_info_15:
+	.byte $0A, $0D, "First sector LBA: ", $00
+
+partition_info_16:
+	.byte $0A, $0D, "Sector count: ", $00
+
+partition_info_17:
+	.byte $0A, $0D, "Partition type: ", $00
+
+partition_info_18:
+	.asciiz " - "
+
+partition_types:
+	.byte $0C
+	.word partition_type_fat32_lba
+	.byte $1C
+	.word partition_type_hidden_fat32_lba
+	.byte $07
+	.word partition_type_ntfs
+	.byte $17
+	.word partition_type_hidden_ntfs
+	.byte $00
+
+partition_type_fat32_lba:
+	.asciiz "W95 FAT32 (LBA)"
+
+partition_type_hidden_fat32_lba:
+	.asciiz "Hidden W95 FAT32 (LBA)"
+
+partition_type_ntfs:
+	.asciiz "HPFS/NTFS/exFAT"
+
+partition_type_hidden_ntfs:
+	.asciiz "Hidden HPFS/NTFS/exFAT"
+
+write_success:
+	.byte "The partition table has been altered.", $0A, $0D, "Syncing disks.", $0A, $0D, $00
+
+write_error:
+	.asciiz "Error writing partition table to disk."

--- a/utility/commands.s
+++ b/utility/commands.s
@@ -198,8 +198,7 @@ print_loop:
 	bra :--
 
 @error:
-	clc
-	print new_partition_out_of_range
+	print value_out_of_range
 	jmp print_loop
 
 @success:
@@ -422,7 +421,7 @@ partition_type_loop:
 	cmp #'e'
 	beq @extended
 
-	print new_partition_out_of_range
+	print value_out_of_range
 	bra partition_type_loop
 
 @default:
@@ -558,8 +557,7 @@ first_sector:
 	bpl :--
 
 @error:
-	clc
-	print new_partition_out_of_range
+	print value_out_of_range
 	jmp first_sector
 
 
@@ -646,8 +644,7 @@ sector_count:
 	bpl :--
 
 @error:
-	clc
-	print new_partition_out_of_range
+	print value_out_of_range
 	jmp sector_count
 
 @success:
@@ -918,6 +915,9 @@ three_spaces_with_newline:
 two_spaces_with_newline:
 	.byte $0A, $0D, $0A, $0D, ' ', ' ', $00
 
+value_out_of_range:
+	.byte $1C, "Value type out of range.", $05, $0A, $0D, $00
+
 select_used_partition_no_used_partition:
 	.byte $1C, "No partition is defined yet!", $05, $0A, $0D, $00
 
@@ -962,9 +962,6 @@ new_partition_type_4:
 
 new_partition_type_5:
 	.byte " free)", $0A, $0D, "   e  extended (container for logical partitions)", $0A, $0D, "Select (default p): ", $00
-
-new_partition_out_of_range:
-	.byte $1C, "Value type out of range.", $05, $0A, $0D, $00
 
 new_partition_type_default:
 	.byte "Using default response p.", $0A, $0D, $00

--- a/utility/fdisk.s
+++ b/utility/fdisk.s
@@ -1,0 +1,7 @@
+.include "banks.inc"
+
+.code
+
+.proc fdisk
+    rts
+.endproc

--- a/utility/fdisk.s
+++ b/utility/fdisk.s
@@ -264,6 +264,7 @@ key_backspace:
 	bra :-
 
 key_enter:
+	stz line_buffer,x
 	clv
 	jmp bsout
 key_runstop:

--- a/utility/fdisk.s
+++ b/utility/fdisk.s
@@ -1,7 +1,414 @@
 .include "banks.inc"
+.include "kernal.inc"
+.include "macros.inc"
+.include "regs.inc"
+
+.include "../dos/fat32/lib.inc"
+
+.export fdisk, read_mbr_sector, write_mbr_sector, create_empty_mbr
+.export parse_u32_hex, parse_u8_hex, print_u8_hex
+.export putstr_ptr, putstr, tmp2, util_tmp
+.import fdisk_commands
+
+.segment "ZPKERNAL" : zeropage
+	tmp2: .res 2
+
+	putstr_ptr = tmp2
+
+.segment "ZPUTIL" : zeropage
+	util_tmp: .res 2
+
+.bss
+
+line_buffer:
+	.res 255
+
+line_number:
+	.res 4
 
 .code
 
+.macro stp
+	.byte $DB
+.endmacro
+
+; *********************************************************************
+; *                                                                   *
+; *********************************************************************
+
 .proc fdisk
-    rts
+.export command_loop_exit
+	lda ram_bank
+	pha
+	stz ram_bank
+
+	printc $0F ; ISO mode
+	print welcome
+
+	jsr read_mbr_sector
+	bcs :+
+
+	print sdcard_read_error
+	jsr create_empty_mbr
+
+:   lda sector_buffer + mbr::signature
+	cmp #$55
+	bne :+
+	lda sector_buffer + mbr::signature + 1
+	cmp #$AA
+	beq command_loop
+
+:   print invalid_mbr_error
+	jsr create_empty_mbr
+
+command_loop:
+	print command_prompt
+
+	jsr read_character
+	beq command_loop
+
+	cmp #$03 ; RUN/STOP
+	beq command_loop_exit
+
+	tay
+
+	cmp #'a'
+	bcc @error
+	
+	cmp #'z' + 1
+	bcs @error
+
+	sec
+	sbc #'a'
+	asl
+	tax
+
+	lda fdisk_commands + 1,x
+	beq @error ; Command addresses are not in the zero page
+	tay
+
+	lda #>(command_loop) ; Push return address
+	pha
+	lda #<(command_loop) - 1
+	pha
+
+	lda #$0A
+	jsr bsout
+	lda #$0D
+	jsr bsout
+
+	phy
+	lda fdisk_commands,x
+	pha
+
+	rts ; Execute command
+
+@error:
+	lda #$1C
+	jsr bsout
+	tya
+	jsr bsout
+	print invalid_command
+	bra command_loop
+
+command_loop_exit:
+	printc $8F
+
+	pla
+	sta ram_bank
+	rts
 .endproc
+
+.proc putstr ; string to print in putstr_ptr
+	ldy #0
+:   lda (putstr_ptr),y
+	beq :+
+	jsr bsout
+	iny
+	bne :-
+:   rts
+.endproc
+
+.proc read_mbr_sector
+	lda #8
+	jsr jsrfar
+	.word sdcard_check
+	.byte BANK_CBDOS
+
+	bcc :+
+	clc
+	rts
+
+:   set32_val sector_lba, 0
+
+	jsr jsrfar
+	.word sdcard_read_sector
+	.byte BANK_CBDOS
+	rts
+.endproc
+
+.proc write_mbr_sector
+	lda #8
+	jsr jsrfar
+	.word sdcard_check
+	.byte BANK_CBDOS
+
+	bcc :+
+	clc
+	rts
+
+:   clc
+	set32_val sector_lba, 0
+	.byte $DB
+
+	jsr jsrfar
+	.word sdcard_write_sector
+	.byte BANK_CBDOS
+	
+	rts
+.endproc
+
+.proc create_empty_mbr
+	lda #00
+	ldy #00
+:   sta sector_buffer,y
+	iny
+	bne :-
+
+	ldy #00
+:   sta sector_buffer + 256,y
+	iny
+	bne :-
+
+	lda #$55
+	sta sector_buffer + mbr::signature
+	lda #$AA
+	sta sector_buffer + mbr::signature + 1
+
+	jsr generate_disk_signature
+
+	print empty_mbr_created
+
+	lda sector_buffer + mbr::disk_signature
+	jsr print_u8_hex
+	lda sector_buffer + mbr::disk_signature + 1
+	jsr print_u8_hex
+	lda sector_buffer + mbr::disk_signature + 2
+	jsr print_u8_hex
+	lda sector_buffer + mbr::disk_signature + 3
+	jmp print_u8_hex
+.endproc
+
+.proc generate_disk_signature
+	jsr entropy_get
+	sta sector_buffer + mbr::disk_signature
+	stx sector_buffer + mbr::disk_signature + 1
+	sty sector_buffer + mbr::disk_signature + 2
+	jsr entropy_get
+	sta sector_buffer + mbr::disk_signature + 3
+	rts
+.endproc
+
+; *********************************************************************
+; Reads a line from stdin.
+; Returns the number of characters read in X.
+; Clobbers: A, X, Y
+; *********************************************************************
+
+.proc read_line
+	ldx #0
+:   phx
+	jsr getin
+	plx
+	cmp $00
+	beq :-
+	cmp #$0D ; ENTER?
+	beq key_enter
+
+	cmp #$14 ; BACKSPACE
+	beq key_backspace
+
+	cpx #$FF ; Buffer full?
+	beq :-
+
+	sta line_buffer,x
+	inx
+
+	cmp #$03 ; RUN/STOP
+	beq key_runstop
+
+	jsr bsout
+	bra :-
+
+key_backspace:
+	cpx #0
+	beq :-
+
+	jsr bsout
+	dex
+	bra read_line
+
+key_enter:
+	jsr bsout
+key_runstop:
+	rts
+.endproc
+
+
+; *********************************************************************
+; Reads a character from stdin and stores it in A.
+; Does not touch A if no character was read.
+; Output: A
+; Clobbers: A, X, Y
+; *********************************************************************
+
+.proc read_character
+	jsr read_line
+	cpy #$00
+	beq :+
+	lda line_buffer
+:   rts
+.endproc
+
+; *********************************************************************
+; Reads 8 characters from line_buffer, converts them into a hexadecimal number and stores it in the buffer pointed to by r0.
+; Sets the carry flag if the number is invalid.
+; X indicates the start position.
+; Clobbers: A, X, Y, r0
+; *********************************************************************
+
+.proc parse_u32_hex
+	ldy #08
+
+:   jsr parse_u8_hex
+	bcs error
+	sta (r0),y
+	inx
+	inx
+	dey
+	bne :-
+
+error:
+	rts
+.endproc
+
+; *********************************************************************
+; Reads an 8 bit hexadecimal number from line_buffer and stores it in A.
+; Sets the carry flag if the number is invalid.
+; X indicates the start position.
+; Input: line_buffer, X
+; Output: A
+; Clobbers: A, tmp2
+; *********************************************************************
+
+.proc parse_u8_hex
+	lda line_buffer + 1,x
+	jsr parse_u4_hex
+	bcs error
+
+	sta tmp2
+
+	lda line_buffer,x
+	jsr parse_u4_hex
+	bcs error
+
+	asl
+	asl
+	asl
+	asl
+
+	ora tmp2
+	clc
+
+error:
+	rts
+.endproc
+
+; *********************************************************************
+; Converts the hexadecimal character in A to a number and stores it in A.
+; Sets the carry flag if the number is invalid.
+; Input: A
+; Output: A
+; Clobbers: A
+; *********************************************************************
+
+.proc parse_u4_hex
+	cmp #'0'
+	bcc error
+
+	cmp #'9' + 1
+	bcs hex
+	sec
+	sbc #'0'
+	rts
+
+hex:
+	cmp #'A'
+	bcc error
+
+	cmp #'F' + 1
+	bcs lowercase
+	adc #10
+	sec
+	sbc #'A'
+	rts
+
+lowercase:
+	sec
+	sbc #('a' - 'A')
+	bra hex
+
+error:
+	sec
+	rts
+.endproc
+
+; Prints the number in A as a hex value.
+; Clobbers: A, X
+.proc print_u8_hex
+    tax
+    and #$F0
+    lsr
+    lsr
+    lsr
+    lsr
+    jsr print_u4_hex
+    txa
+    and #$0F
+    jmp print_u4_hex
+.endproc
+
+.proc print_u4_hex
+    cmp #9
+    bcs letter
+    adc #'0'
+    jmp bsout
+letter:
+    adc #'A' - 11 ; carry is set
+    jmp bsout
+.endproc
+
+
+; *********************************************************************
+.data
+
+welcome:
+	.byte "Welcome to fdisk.", $0A, $0D
+	.byte "Changes will remain in memory only, until you decide to write them.", $0A, $0D
+	.byte "Be careful using the write command.", $0A, $0D, $00
+
+sdcard_read_error:
+	.byte "Failed to read from SD card.", $0A, $0D, $00
+
+invalid_mbr_error:
+	.byte "Device does not contain a recognized partition table.", $0A, $0D, $00
+
+empty_mbr_created:
+	.asciiz "Created a new DOS disklabel with disk identifier 0x"
+
+command_prompt:
+	.byte $0A, $0D, $0A, $0D
+	.asciiz "Command (m for help): "
+
+invalid_command:
+	.byte ": unknown command.", $05, $00

--- a/utility/fdisk.s
+++ b/utility/fdisk.s
@@ -299,7 +299,7 @@ key_runstop:
 ; Reads 8 characters from line_buffer, converts them into a hexadecimal number and stores it in the buffer pointed to by r0.
 ; Sets the carry flag if the number is invalid.
 ; X indicates the start position.
-; Clobbers: A, X, Y, r0
+; Clobbers: A, X, Y, tmp2, r0
 ; *********************************************************************
 
 .proc parse_u32_hex

--- a/utility/fdisk.s
+++ b/utility/fdisk.s
@@ -45,7 +45,16 @@ sector_size:
 	pha
 	stz ram_bank
 
-	printc $0F ; ISO mode
+	lda #8
+	jsr jsrfar
+	.word sdcard_check
+	.byte BANK_CBDOS
+
+	bcc :+
+	print sdcard_not_found
+	jmp fdisk_exit
+
+:	printc $0F ; ISO mode
 	print welcome
 
 	set32_val sector_size, 2048 ; FIXME: Query from SD card
@@ -119,6 +128,7 @@ command_loop:
 command_loop_exit:
 	printc $8F
 
+fdisk_exit:
 	pla
 	sta ram_bank
 	rts
@@ -419,6 +429,9 @@ letter:
 
 ; *********************************************************************
 .data
+
+sdcard_not_found: ; PETSCII!
+	.byte "NO SD CARD DETECTED.", $0D, $00
 
 welcome:
 	.byte "Welcome to fdisk.", $0D

--- a/utility/fdisk.s
+++ b/utility/fdisk.s
@@ -327,22 +327,23 @@ error:
 ; *********************************************************************
 
 .proc parse_u8_hex
-	lda line_buffer + 1,x
+	lda line_buffer,x
 	jsr parse_u4_hex
 	bcs error
 
 	sta tmp2
 
-	lda line_buffer,x
+	lda line_buffer + 1,x
+	beq :+
 	jsr parse_u4_hex
 	bcs error
 
-	asl
-	asl
-	asl
-	asl
+	asl tmp2
+	asl tmp2
+	asl tmp2
+	asl tmp2
 
-	ora tmp2
+:   ora tmp2
 	clc
 
 error:

--- a/utility/fdisk.s
+++ b/utility/fdisk.s
@@ -421,21 +421,21 @@ letter:
 .data
 
 welcome:
-	.byte "Welcome to fdisk.", $0A, $0D
-	.byte "Changes will remain in memory only, until you decide to write them.", $0A, $0D
-	.byte "Be careful using the write command.", $0A, $0D, $00
+	.byte "Welcome to fdisk.", $0D
+	.byte "Changes will remain in memory only, until you decide to write them.", $0D
+	.byte "Be careful using the write command.", $0D, $00
 
 sdcard_read_error:
-	.byte "Failed to read from SD card.", $0A, $0D, $00
+	.byte "Failed to read from SD card.", $0D, $00
 
 invalid_mbr_error:
-	.byte "Device does not contain a recognized partition table.", $0A, $0D, $00
+	.byte "Device does not contain a recognized partition table.", $0D, $00
 
 empty_mbr_created:
 	.asciiz "Created a new DOS disklabel with disk identifier 0x"
 
 command_prompt:
-	.byte $0A, $0D, $0A, $0D
+	.byte $0D, $0D
 	.asciiz "Command (m for help): "
 
 invalid_command:

--- a/utility/jumptab.s
+++ b/utility/jumptab.s
@@ -1,0 +1,7 @@
+.import fdisk, read_mbr_sector, write_mbr_sector
+
+.segment "UTILTBL"
+
+jmp fdisk
+jmp read_mbr_sector
+jmp write_mbr_sector

--- a/utility/macros.inc
+++ b/utility/macros.inc
@@ -1,0 +1,43 @@
+sector_buffer = $B000
+sdcard_param = $B200
+sector_lba = sdcard_param + 1
+cmd_idx = sdcard_param
+cmd_arg = sdcard_param + 1
+cmd_crc = sdcard_param + 5
+
+.macro print str
+	set16_val putstr_ptr, str
+	jsr putstr
+.endmacro
+
+.macro print_tail str
+	set16_val putstr_ptr, str
+	jmp putstr
+.endmacro
+
+.macro printc c
+	lda #c
+	jsr bsout
+.endmacro
+
+.struct mbr
+	bootcode .res 440
+	disk_signature .res 4
+	null .res 2
+	partition_table .res 64
+	signature .res 2
+.endstruct
+
+.struct partition_table_entry
+	bootable .res 1
+	first_sector_chs .res 3
+	partition_type .res 1
+	last_sector_chs .res 3
+	first_sector_lba .res 4
+	sector_count .res 4
+.endstruct
+
+sdcard_read_sector = $C000 + (23 * 3)
+sdcard_write_sector = $C000 + (24 * 3)
+sdcard_check = $C000 + (25 * 3)
+ram_bank = $00


### PR DESCRIPTION
This PR adds the fdisk utility for partitioning a SD card.

Todo:

- [ ] Integrate it with the new utility bank added in master
- [ ] Use decimal numbers for printing and parsing - for 32bit hexadecimal input, you currently need to enter 8 characters.
- [ ] Correctly work with partition tables that have the partitions out of order.
- [ ] Verify that setting the CHS fields to 0 is correct for devices that don't support CHS addressing.