### PR TITLE
[KERNAL] fix joy detection assuming controllers were always connected

### DIFF
--- a/kernal/drivers/x16/joystick.s
+++ b/kernal/drivers/x16/joystick.s
@@ -81,22 +81,22 @@ l1:	lda nes_data
 	lda joy1+1
 	and #%00001111
 	cmp #15
-	bne :+
+	beq :+
 	sty joy1+2
 :	lda joy2+1
 	and #%00001111
 	cmp #15
-	bne :+
+	beq :+
 	sty joy2+2
 :	lda joy3+1
 	and #%00001111
 	cmp #15
-	bne :+
+	beq :+
 	sty joy3+2
 :	lda joy4+1
 	and #%00001111
 	cmp #15
-	bne :+
+	beq :+
 	sty joy4+2
 :
 


### PR DESCRIPTION
This corrects the behavior introduced by b493150f975bf830e0abc68764adcc48176e9202

Closes #74 