### PR TITLE
[KERNAL/BASIC] Add asserts in a best effort attempt to stablize locations used by cc65's RAM constants

### DIFF
--- a/basic/declare.s
+++ b/basic/declare.s
@@ -3,6 +3,7 @@ lofbuf	=$ff            ;$FF the low fac buffer. copyable
 buflen	=89             ;vic buffer
 bufpag	=2
 buf	=512
+.assert buf = 512, error, "cc65 depends on BASIC_BUF = $200, change with caution"
 stkend	=507
 clmwid	=10             ;print window 10 chars
 pi	=255
@@ -40,6 +41,7 @@ eormsk	=forpnt+1        ;$4A the mask for eoring in wait
 ; CHRGET
 chrget	.res 6           ;$73
 chrgot	.res 1           ;$79
+.assert * = $EE, error, "cc65 depends on TXTPTR = $EE, change with caution"
 txtptr	.res 6           ;$7A
 qnum	.res 11          ;$80
 
@@ -101,6 +103,7 @@ temppt	.res 1           ;$16 pointer at first free temp descriptor
                          ;    initialized to point to tempst
 
 lastpt	.res 2           ;$17 pointer to last-used string temporary
+.assert * = $03E1, error, "cc65 depends on VARTAB = $03E1, change with caution"
 vartab	.res 2           ;$2D pointer to start of simple
                          ;    variable space.
                          ;    updated whenever the size of the
@@ -116,6 +119,7 @@ strend	.res 2           ;$31end of storage in use.
                          ;    or simple variable is encountered.
                          ;    set to [vartab] by "clearc".
 fretop	.res 2           ;$33 top of string free space
+.assert * = $03E9, error, "cc65 depends on MEMSIZ = $03E9, change with caution"
 memsiz	.res 2           ;$37 highest location in memory
 
 ; --- line numbers and textual pointers ---:

--- a/kernal/cbm/channel/channel.s
+++ b/kernal/cbm/channel/channel.s
@@ -100,6 +100,7 @@ sal	.res 1           ;$AC
 sah	.res 1           ;$AD
 eal	.res 1           ;$AE
 eah	.res 1           ;$AF
+.assert * = $8A, error, "cc65 depends on FNAM = $8A, change with caution"
 fnadr	.res 2           ;$BB addr current file name str
 memuss	.res 2           ;$C3 load temps
 
@@ -111,18 +112,24 @@ lat	.res 10          ;    logical file numbers
 fat	.res 10          ;    primary device numbers
 sat	.res 10          ;    secondary addresses
 .assert * = status, error, "update banks.inc!"
+.assert * = $0287, error, "cc65 depends on STATUS = $0287, change with caution"
 __status
 	.res 1           ;$90 i/o operation status byte
 verck	.res 1           ;$93 load or verify flag
 xsav	.res 1           ;$97 temp for basin
 ldtnd	.res 1           ;$98 index to logical file
+.assert * = $028B, error, "cc65 depends on IN_DEV = $028B, change with caution"
 dfltn	.res 1           ;$99 default input device #
+.assert * = $028C, error, "cc65 depends on OUT_DEV = $028C, change with caution"
 dflto	.res 1           ;$9A default output device #
 msgflg	.res 1           ;$9D os message flag
 t1	.res 1           ;$9E temporary 1
+.assert * = $028F, error, "cc65 depends on FNAM_LEN = $028F, change with caution"
 fnlen	.res 1           ;$B7 length current file n str
 la	.res 1           ;$B8 current file logical addr
+.assert * = $0291, error, "cc65 depends on SECADR = $0291, change with caution"
 sa	.res 1           ;$B9 current file 2nd addr
+.assert * = $0292, error, "cc65 depends on DEVADR = $0292, change with caution"
 fa	.res 1           ;$BA current file primary addr
 stal	.res 1           ;$C1
 stah	.res 1           ;$C2

--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -105,26 +105,37 @@ ldtb1	.res 61 +1       ;flags+endspace
 .export data; [cpychr]
 mode	.res 1           ;    bit7=1: charset locked, bit6=1: ISO
                          ;    bits3-0: current charset
+.assert * = $0373, error, "cc65 depends on CURS_COLOR = $0373, change with caution"
 gdcol	.res 1           ;    original color before cursor
 autodn	.res 1           ;    auto scroll down flag(=0 on,<>0 off)
 lintmp	.res 1           ;    temporary for line index
+.assert * = $0376, error, "cc65 depends on CHARCOLOR = $0376, change with caution"
 color	.res 1           ;    activ color nybble
+.assert * = $0377, error, "cc65 depends on RVS = $0377, change with caution"
 rvs	.res 1           ;$C7 rvs field on flag
 indx	.res 1           ;$C8
 lsxp	.res 1           ;$C9 x pos at start
 lstp	.res 1           ;$CA
+.assert * = $037B, error, "cc65 depends on CURS_FLAG = $037B, change with caution"
 blnsw	.res 1           ;$CC cursor blink enab
+.assert * = $037C, error, "cc65 depends on CURS_BLINK = $037C, change with caution"
 blnct	.res 1           ;$CD count to toggle cur
+.assert * = $037D, error, "cc65 depends on CURS_CHAR = $037D, change with caution"
 gdbln	.res 1           ;$CE char before cursor
+.assert * = $037E, error, "cc65 depends on CURS_STATE = $037E, change with caution"
 blnon	.res 1           ;$CF on/off blink flag
 crsw	.res 1           ;$D0 input vs get flag
+.assert * = $0380, error, "cc65 depends on CURS_X = $0380, change with caution"
 pntr	.res 1           ;$D3 pointer to column
 qtsw	.res 1           ;$D4 quote switch
 lnmx	.res 1           ;$D5 40/80 max positon
+.assert * = $0383, error, "cc65 depends on CURS_Y = $0383, change with caution"
 tblx	.res 1           ;$D6
 data	.res 1           ;$D7
 insrt	.res 1           ;$D8 insert mode flag
+.assert * = $0386, error, "cc65 depends on LLEN = $0386, change with caution"
 llen	.res 1           ;$D9 x resolution
+.assert * = $0387, error, "cc65 depends on NLINES = $0387, change with caution"
 nlines	.res 1           ;$DA y resolution
 nlinesp1 .res 1          ;    X16: y resolution + 1
 nlinesm1 .res 1          ;    X16: y resolution - 1

--- a/kernal/declare.s
+++ b/kernal/declare.s
@@ -16,6 +16,7 @@ mhz     =8
 .segment "ZPKERNAL" : zeropage
 ;                      C64 location
 ;                         VVV
+.assert * = $80, error, "cc65 depends on KTEMP2 = $80, change with caution"
 tmp2	.res 2           ;$C3
 .assert * = imparm, error, "imparm must be at specific address"
 __imparm

--- a/kernal/drivers/x16/screen.s
+++ b/kernal/drivers/x16/screen.s
@@ -50,6 +50,7 @@
 .segment "KVAR"
 
 cscrmd:	.res 1           ;    X16: current screen mode (argument to screen_mode)
+.assert * = $0262, error, "cc65 depends on SCREEN_PTR = $0262, change with caution"
 pnt:	.res 2           ;$D1 pointer to row
 
 .segment "SCREEN"


### PR DESCRIPTION
PR opened at cc65 https://github.com/cc65/cc65/pull/2040 to update these constants to their R42 locations.