### PR TITLE
Monitor init bug fix

### DIFF
--- a/monitor/monitor.s
+++ b/monitor/monitor.s
@@ -166,6 +166,7 @@ monitor:
 	lda #'C'
 	sta entry_type
 	lda #DEFAULT_BANK
+	sta bank
 	stz bank_flags
 	ldx #<(__monitor_ram_code_SIZE__ - 1)
 :	lda __monitor_ram_code_LOAD__,x

--- a/monitor/monitor.s
+++ b/monitor/monitor.s
@@ -166,7 +166,7 @@ monitor:
 	lda #'C'
 	sta entry_type
 	lda #DEFAULT_BANK
-	sta bank
+	stz bank_flags
 	ldx #<(__monitor_ram_code_SIZE__ - 1)
 :	lda __monitor_ram_code_LOAD__,x
 	sta __monitor_ram_code_RUN__,x


### PR DESCRIPTION
I think I isolated the monitor init problem mention in issue #85 to address $2D (bank_flags).
This should be cleared on monitor startup.