### PR TITLE
[BUILD] avoid shell-builtin of echo command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -428,8 +428,8 @@ clean:
 
 $(GIT_SIGNATURE): FORCE
 	@mkdir -p $(BUILD_DIR)
-	git diff --quiet && echo -n $$( (git rev-parse --short=8 HEAD || echo "00000000") | tr '[:lower:]' '[:upper:]') > $(GIT_SIGNATURE) \
-	|| echo -n $$( echo -n $$(git rev-parse --short=7 HEAD || echo "0000000") | tr '[:lower:]' '[:upper:]'; echo -n '+') > $(GIT_SIGNATURE)
+	git diff --quiet && /bin/echo -n $$( (git rev-parse --short=8 HEAD || /bin/echo "00000000") | tr '[:lower:]' '[:upper:]') > $(GIT_SIGNATURE) \
+	|| /bin/echo -n $$( /bin/echo -n $$(git rev-parse --short=7 HEAD || echo "0000000") | tr '[:lower:]' '[:upper:]'; /bin/echo -n '+') > $(GIT_SIGNATURE)
 
 FORCE:
 


### PR DESCRIPTION
This seems to fix the build signature on MacOS by ensuring that the echo command is the binary in /bin rather than the shell builtin of whatever the current shell is.  This change also appears to work on our other supported build targets.  If we ever decide to target FreeBSD we might need a conditional here :)

Closes #86 