### PR TITLE
Adjustments to fb_fill_pixels

### DIFF
--- a/graphics/drivers/framebuffer.s
+++ b/graphics/drivers/framebuffer.s
@@ -425,31 +425,64 @@ fill_pixels_non_accelerated:
 	inc r0H
 	clc
 
-@loop:
+	; increment larger than 255?
+	lda r1H
+	bne fill_pixels_non_accelerated_16bit
+
+	lda VERA_ADDR_L
+
+@loop8bit:
+
+	sty VERA_DATA0
+
+	; increment with r1 (step size)
+	adc r1L
+	sta VERA_ADDR_L
+	bcs @incrementM
+
+@resumeLoop8:
+	dex
+	bne @loop8bit
+	dec r0H
+	bne @loop8bit
+	bra fill_pixels_reset_increment_and_rts
+
+@incrementM:
+	; carry, increment M and H addresses
+	clc
+	inc VERA_ADDR_M
+	bne @resumeLoop8
+	inc VERA_ADDR_H
+	bra @resumeLoop8
+
+
+fill_pixels_non_accelerated_16bit:
+
+@loop16bit:
 
 	sty VERA_DATA0
 
 	lda VERA_ADDR_L
 	adc r1L
 	sta VERA_ADDR_L
-	lda r1H
-	bcs @incrementM
-	bne @incrementM
 
-@resumeLoop:
+	lda VERA_ADDR_M
+	adc r1H
+	sta VERA_ADDR_M
+
+	bcs @incrementH
+
+@resumeLoop16:
 	dex
-	bne @loop
+	bne @loop16bit
 	dec r0H
-	bne @loop
+	bne @loop16bit
 	bra fill_pixels_reset_increment_and_rts
 
-@incrementM:
-	adc VERA_ADDR_M
-	sta VERA_ADDR_M
-	bcc @resumeLoop
+@incrementH:
 	inc VERA_ADDR_H
 	clc
-	bra @resumeLoop
+	bra @resumeLoop16
 
 ;---------------------------------------------------------------
 ; FB_filter_pixels

--- a/graphics/drivers/framebuffer.s
+++ b/graphics/drivers/framebuffer.s
@@ -339,8 +339,8 @@ FB_fill_pixels:
 	beq @2
 
 ; full blocks, 8 bytes at a time
-	ldy #$20
-@1:	jsr fill_y
+@1:	ldy #$20
+	jsr fill_y
 	dex
 	bne @1
 


### PR DESCRIPTION
This pull request fixes two bugs in fb_fill_pixels, which also reduces code size.

This also adds the feature of supporting arbitrary step sizes as parameter, increasing code size with either 60 or 93 bytes.

Arbitrary step size is requested here https://github.com/commanderx16/x16-rom/issues/100 . The original code also mentioned "TODO support other step sizes".

I am not familiar with how much space we can use for new features. Looking at the map file, however, it appears that DB5E to FFF9 (9.372 bytes) is available in bank 8. This is after adding the new features included here. Thus, it appears to me that we can afford some bytes for this feature.

Future improvements may be to look for all increments that can be accelerated by VERA (1,2,4,8,16,32,64,128,256,512,40,80,160,320,640), given that this lookup is not too slow nor too bulky.