### PR TITLE
[BASIC] new keywords LINPUT, LINPUT#, and BINPUT#

### DIFF
--- a/basic/token2.s
+++ b/basic/token2.s
@@ -114,7 +114,10 @@ reslst3
 	.byt "BSAV", 'E' + $80
 	.byt "MEN", 'U' + $80
 	.byt "RE", 'N' + $80
-	
+	.byt "LINPUT", '#' + $80
+	.byt "LINPU", 'T' + $80
+	.byt "BINPUT", '#' + $80
+
 	; add new statements before this line
 
 	; functions start here

--- a/basic/tokens.s
+++ b/basic/tokens.s
@@ -135,6 +135,9 @@ stmdsp2	; statements
 	.word cbsave-1
 	.word cmenu-1
 	.word cren-1
+	.word linputn-1
+	.word linput-1
+	.word binputn-1
 
 	; functions
 ptrfunc	.word vpeek


### PR DESCRIPTION
Along with `POINTER()` and `STRPTR()`, I believe these routines satisfy most of the deficiencies that led to @tomxp411's requests in #44 

Here's an interesting use for `LINPUT#` to parse out directory entries:
![image](https://github.com/X16Community/x16-rom/assets/395186/515e59cd-8016-430e-8780-15cbdcd704d4)

And here's a couple `BINPUT#` examples.  The file contains newlines (`$0A`) but no CRs (`$0D`), so they don't display, but the string is getting the bytes.
![image](https://github.com/X16Community/x16-rom/assets/395186/831702b0-9bf4-41a0-8419-3700c6a6d145)

Closes #44