### PR TITLE
[CI/CD] separate build for release ROM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,14 +19,28 @@ jobs:
           make -j4
           sudo make install
       - name: Build ROM
+        if: startsWith(github.ref, 'refs/tags/r') != true
         run: |
           make
+      - name: Build Release ROM
+        if: startsWith(github.ref, 'refs/tags/r')
+        run: |
+          PRERELEASE_VERSION=$(echo "$GITHUB_REF_NAME" | grep -oP '[0-9]+$') make
+      - name: Archive Build Result
+        run: |
           mkdir artifact
           cp build/x16/*.h artifact/.
           cp build/x16/*.sym artifact/.
           cp build/x16/rom.bin artifact/.
-      - name: Archive Build Result
+      - name: Upload Artifacts (non-release)
+        if: startsWith(github.ref, 'refs/tags/r') != true
         uses: actions/upload-artifact@v3
         with:
           name: ROM Image
+          path: artifact
+      - name: Upload Artifacts (release)
+        if: startsWith(github.ref, 'refs/tags/r')
+        uses: actions/upload-artifact@v3
+        with:
+          name: Release ROM Image
           path: artifact


### PR DESCRIPTION
Having a separate Release ROM image artifact will allow us to simplify automating builds for release x16emu, so that we no longer build the ROM in the emu CI.