### PR TITLE
[UTIL] refix return to basic, handle RTC 12h mode

### DIFF
--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -792,7 +792,8 @@ cmenu:
 	jsr bjsrfar
 	.word $c000
 	.byte BANK_UTIL
-	rts
+	jsr stkini
+	jmp readyx
 
 ; REN [newstart[,increment[,oldstart]]]
 ; line renumber


### PR DESCRIPTION
This should be an actual fix for the return to BASIC from the menu command.  This no longer requires clearing the temporary use of the buffer since BASIC will now completely ignore it.  This also means the return from MENU will be to the READY prompt even if MENU were to be called from within a program.  This is probably the only sane behavior anyway since MENU borrows BASIC buffer space.

Control program now handles updating rtc clock to 24h mode if the time/date screen finds that it's in am/pm 12h mode.