### PR TITLE
[EDITOR] (Shift+)END, DEL, cursor blink fixes

### DIFF
--- a/kernal/drivers/x16/screen.s
+++ b/kernal/drivers/x16/screen.s
@@ -18,6 +18,7 @@
 .export screen_set_char_color
 .export screen_get_char_color
 .export screen_set_position
+.export screen_get_position
 .export screen_copy_line
 .export screen_clear_line
 .export screen_save_state
@@ -339,6 +340,16 @@ trows:	.byte  60,  30,  60,  30,  15,  30,  15,  23,  50,  25,  50,  25,  30
 screen_set_position:
 	stz pnt
 	stx pnt+1
+	rts
+
+;---------------------------------------------------------------
+; Retrieve start of line
+;
+;   In:   pmt  line
+;   Out:  .x   line
+;---------------------------------------------------------------
+screen_get_position:
+	ldx pnt+1
 	rts
 
 ;---------------------------------------------------------------


### PR DESCRIPTION
END now puts the cursor at the end of the line, Shift+END puts the cursor on the last row.
The cursor blink on used to be one frame after a key, now it's the same frame the key is processed.
DEL (not Backspace) will delete the character under the cursor. It does what a right cursor key would do, then processes it as if it were a backspace.

Closes #103 
Closes #104 
Closes #105 
