### PR TITLE
[MONITOR] support key code changes, work around ghost cursor

### DIFF
--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -118,15 +118,19 @@ indx	.res 1           ;$C8
 lsxp	.res 1           ;$C9 x pos at start
 lstp	.res 1           ;$CA
 .assert * = $037B, error, "cc65 depends on CURS_FLAG = $037B, change with caution"
+.assert * = $037B, error, "a hack in monitor/irq.s depends on BLNSW = $037B."
 blnsw	.res 1           ;$CC cursor blink enab
 .assert * = $037C, error, "cc65 depends on CURS_BLINK = $037C, change with caution"
 blnct	.res 1           ;$CD count to toggle cur
 .assert * = $037D, error, "cc65 depends on CURS_CHAR = $037D, change with caution"
+.assert * = $037D, error, "a hack in monitor/irq.s depends on GDBLN = $037D."
 gdbln	.res 1           ;$CE char before cursor
 .assert * = $037E, error, "cc65 depends on CURS_STATE = $037E, change with caution"
+.assert * = $037E, error, "a hack in monitor/irq.s depends on BLNON = $037E."
 blnon	.res 1           ;$CF on/off blink flag
 crsw	.res 1           ;$D0 input vs get flag
 .assert * = $0380, error, "cc65 depends on CURS_X = $0380, change with caution"
+.assert * = $0380, error, "a hack in monitor/irq.s depends on PNTR = $0380"
 pntr	.res 1           ;$D3 pointer to column
 qtsw	.res 1           ;$D4 quote switch
 lnmx	.res 1           ;$D5 40/80 max positon

--- a/kernal/drivers/x16/screen.s
+++ b/kernal/drivers/x16/screen.s
@@ -444,6 +444,7 @@ screen_set_color:
 ;         pnt      line location
 ;   Out:  -
 ;---------------------------------------------------------------
+.assert * = $CA1C, error, "a hack in monitor/irqs depends on screen_set_char = $CA1C"
 screen_set_char:
 	pha
 	phx ; preserve X

--- a/monitor/irq.s
+++ b/monitor/irq.s
@@ -83,6 +83,7 @@ keyhandler2:
 	bne @not_f3
 ; F3
 @scroll_up:
+	jsr clear_cursor
 	jsr cursor_top
 	jsr LB75E
 	lda #0
@@ -95,6 +96,7 @@ keyhandler2:
 
 ; F5
 @scroll_down:
+	jsr clear_cursor
 	jsr cursor_bottom
 	jsr LB75E
 	lda #0
@@ -381,4 +383,22 @@ LB913:	sec
 	dec tmp13
 	bne LB913
 :	rts
+
+clear_cursor:
+ 	lda #$FF
+ 	sta BLNSW
+ 	lda BLNON
+ 	beq LB8EB ; rts
+ 	lda GDBLN
+ 	ldy $380
+ 	jsr jsrfar 
+	.word $CA1C
+	.byt 0
+ 	lda #0
+ 	sta BLNON
+ LB8EB:	rts
+
+ BLNSW = $37b
+ BLNON = $37e
+ GDBLN = $37d
 

--- a/monitor/irq.s
+++ b/monitor/irq.s
@@ -1,5 +1,6 @@
 plot = $fff0
 
+.include "keycode.inc"
 .export enable_f_keys
 .export disable_f_keys
 
@@ -45,26 +46,25 @@ keyhandler:
 .segment "monitor"
 
 keyhandler2:
-	bcc :+ ; down
+	and #$ff
+	bpl :+ ; down
+
 @ret:	rts
 :	bit f_keys_disabled
 	bmi @ret
 
-	cpx #0
-	bne @not_prefix_00
-
-	cmp #$05 ; F1
+	cmp #KEYCODE_F1 ; F1
 	beq @eat
-	cmp #$06 ; F2
+	cmp #KEYCODE_F2 ; F2
 	beq @eat
-	cmp #$0C ; F4
+	cmp #KEYCODE_F4 ; F4
 	beq @eat
-	cmp #$0B ; F6
+	cmp #KEYCODE_F6 ; F6
 	beq @eat
-	cmp #$0A ; F8
+	cmp #KEYCODE_F8 ; F8
 	beq @eat
 
-	cmp #$83
+	cmp #KEYCODE_F7
 	bne @not_f7
 
 	lda #'@'
@@ -79,7 +79,7 @@ keyhandler2:
 	rts
 
 @not_f7:
-	cmp #4 ; F3
+	cmp #KEYCODE_F3 ; F3
 	bne @not_f3
 ; F3
 @scroll_up:
@@ -90,8 +90,9 @@ keyhandler2:
 	rts
 
 @not_f3:
-	cmp #3 ; F5
-	bne @ret2
+	cmp #KEYCODE_F5 ; F5
+	bne @not_f5
+
 ; F5
 @scroll_down:
 	jsr cursor_bottom
@@ -103,11 +104,8 @@ keyhandler2:
 @ret2:	clc
 	rts
 
-@not_prefix_00:
-	cpx #$e0
-	bne @ret2
-
-	cmp #$72 ; DOWN
+@not_f5:
+	cmp #KEYCODE_DOWNARROW ; DOWN
 	bne @not_down
 
 	pha
@@ -122,7 +120,7 @@ keyhandler2:
 	bra @scroll_down
 
 @not_down:
-	cmp #$75 ; UP
+	cmp #KEYCODE_UPARROW ; UP
 	bne @ret2
 
 	pha

--- a/monitor/irq.s
+++ b/monitor/irq.s
@@ -385,20 +385,23 @@ LB913:	sec
 :	rts
 
 clear_cursor:
- 	lda #$FF
- 	sta BLNSW
- 	lda BLNON
- 	beq LB8EB ; rts
- 	lda GDBLN
- 	ldy $380
- 	jsr jsrfar 
-	.word $CA1C
+	lda #$FF
+	sta BLNSW
+	lda BLNON
+	beq LB8EB ; rts
+	lda GDBLN
+	ldy PNTR
+	; XXX we should remove this hack after refactoring
+	; XXX how the monitor's navigation works
+	; -MooingLemur 2023-05-16
+	jsr jsrfar
+	.word $CA1C ; screen_set_char
 	.byt 0
- 	lda #0
- 	sta BLNON
+	lda #0
+	sta BLNON
  LB8EB:	rts
 
  BLNSW = $37b
  BLNON = $37e
  GDBLN = $37d
-
+ PNTR = $380


### PR DESCRIPTION
This change includes a very brittle hack to clear the cursor when navigating off the bottom or top of the screen.

Refactoring the Monitor's navigation event flow should be one of the next priorities but this should be good enough to get R43 out the door.

Closes #110 