### PR TITLE
[KERNAL] Clean up IRQ and NMI vectors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,7 @@ ifneq ($(MACHINE),c64)
 endif
 
 KEYMAP_SOURCES = \
-	keymap/keymap.s \
-	keymap/vectors.s
+	keymap/keymap.s
 
 DOS_SOURCES = \
 	dos/fat32/fat32.s \
@@ -274,8 +273,7 @@ CHARSET_SOURCES= \
 	charset/petscii.s \
 	charset/iso-8859-15.s \
 	charset/petscii2.s \
-	charset/iso-8859-15_2.s \
-	charset/vectors.s
+	charset/iso-8859-15_2.s
 
 GRAPH_SOURCES= \
 	graphics/jmptbl.s \

--- a/charset/vectors.s
+++ b/charset/vectors.s
@@ -1,6 +1,0 @@
-.include "banks.inc"
-
-.segment "VECTORS"
-	.word banked_nmi
-	.word $ffff
-	.word banked_irq

--- a/codex/src/kernsup_cx.s
+++ b/codex/src/kernsup_cx.s
@@ -35,7 +35,3 @@ mjsrfar:
 	.include "kernsup.inc"
 
 	.byte 0, 0, 0, 0 ; signature
-
-	.word banked_nmi ; nmi
-	.word $ffff ; reset
-	.word banked_irq

--- a/dos/main.s
+++ b/dos/main.s
@@ -545,11 +545,3 @@ dos_macptr:
 
 @1:	sec ; error: unsupported
 	bra @end
-
-
-;---------------------------------------------------------------
-.segment "IRQB"
-	.word banked_nmi
-	.word $ffff
-	.word banked_irq
-

--- a/graphics/jmptbl.s
+++ b/graphics/jmptbl.s
@@ -71,7 +71,3 @@ jmp (I_FB_set_8_pixels_opaque)  ;C057
 jmp (I_FB_fill_pixels)          ;C05A
 jmp (I_FB_filter_pixels)        ;C05D
 jmp (I_FB_move_pixels)          ;C060
-
-.include "banks.inc"
-.segment "VECTORS" 
- .byt <banked_nmi, >banked_nmi, $ff, $ff, <banked_irq, >banked_irq

--- a/inc/banks.inc
+++ b/inc/banks.inc
@@ -22,8 +22,8 @@ jsrfar3    = $02c4 ; jsrfar: RAM part
 jmpfr      = $02df ; jsrfar: core jmp instruction
 imparm     = $82   ; jsrfar: temporary byte
 stavec     = $03b2 ; stash: argument
-banked_irq = $038b ; irq handler: RAM part         this value MUST NEVER CHANGE starting from R42
-banked_nmi = $03b7 ; nmi handler: RAM trampoline   this value MUST NEVER CHANGE starting from R42
+irq        = $038b ; irq handler: RAM part         this value MUST NEVER CHANGE starting from R42
+nmi        = $03b7 ; nmi handler: RAM trampoline   this value MUST NEVER CHANGE starting from R42
 .elseif .defined(MACHINE_C64)
 status     = $029F
 ;fa         = $029F

--- a/kernal/cbm/irq.s
+++ b/kernal/cbm/irq.s
@@ -8,7 +8,7 @@
 
 .import dfltn, dflto, kbd_scan, clock_update, cinv, cbinv
 
-.export puls, key
+.export key
 
 .segment "IRQ"
 
@@ -23,32 +23,6 @@
 .include "banks.inc"
 
 rom_bank = 1
-
-
-; puls - checks for real irq's or breaks
-;
-puls	pha
-	lda rom_bank
-	beq :+
-	pla
-	jmp banked_irq
-:
-.ifp02
-	txa
-	pha
-	tya
-	pha
-	cld
-.else
-	phx
-	phy
-.endif
-	tsx
-	lda $104,x      ;get old p status
-	and #$10        ;break flag?
-	beq puls1       ;...no
-	jmp (cbinv)     ;...yes...break instr
-puls1	jmp (cinv)      ;...irq
 
 ; VBLANK IRQ handler
 ;

--- a/kernal/cbm/nmi.s
+++ b/kernal/cbm/nmi.s
@@ -11,15 +11,9 @@ monitor = $fecc
 .import enter_basic, cint, ioinit, restor, nminv
 .import call_audio_init, screen_set_defaults_from_nvram
 
-.export nmi, nnmi, timb
+.export nnmi, timb
 
 .segment "NMI"
-
-; sets up the stack just like the RAM trampoline does
-nmi	pha
-	lda rom_bank
-	pha
-	jmp (nminv)
 
 ; warm reset, ctrl+alt+restore, default value for (nminv)
 nnmi	jsr ioinit           ;go initilize i/o devices

--- a/kernal/vectors.s
+++ b/kernal/vectors.s
@@ -27,9 +27,11 @@
 
 .import entropy_get
 
-.import restor, memtop, membot, vector, puls, start, nmi, iobase, primm
+.import restor, memtop, membot, vector, start, iobase, primm
 
 .import savehl
+
+.include "banks.inc"
 
 	.segment "JMPTBL"
 
@@ -191,5 +193,5 @@ jiobas	jmp iobase      ;return i/o base
 	.segment "VECTORS"
 	.word nmi        ;program defineable
 	.word start      ;initialization code
-	.word puls       ;interrupt handler
+	.word irq        ;interrupt handler
 

--- a/kernsup/kernsup_audio.s
+++ b/kernsup/kernsup_audio.s
@@ -33,7 +33,3 @@ ajsrfar:
 .include "kernsup.inc"
 
 	.byte 0, 0, 0, 0 ; signature
-
-	.word banked_nmi ; nmi
-	.word $ffff ; reset
-	.word banked_irq

--- a/kernsup/kernsup_bannex.s
+++ b/kernsup/kernsup_bannex.s
@@ -33,7 +33,3 @@ bajsrfar:
 .include "kernsup.inc"
 
 	.byte 0, 0, 0, 0 ; signature
-
-	.word banked_nmi ; nmi
-	.word $ffff ; reset
-	.word banked_irq

--- a/kernsup/kernsup_basic.s
+++ b/kernsup/kernsup_basic.s
@@ -22,7 +22,3 @@ symbol:
 	.include "kernsup.inc"
 
 	.byte 0, 0, 0, 0 ; signature
-
-	.word banked_nmi ; nmi
-	.word $ffff ; reset
-	.word banked_irq

--- a/kernsup/kernsup_monitor.s
+++ b/kernsup/kernsup_monitor.s
@@ -35,7 +35,3 @@ mjsrfar:
 	.include "kernsup.inc"
 
 	.byte 0, 0, 0, 0 ; signature
-
-	.word banked_nmi ; nmi
-	.word $ffff ; reset
-	.word banked_irq

--- a/kernsup/kernsup_util.s
+++ b/kernsup/kernsup_util.s
@@ -33,7 +33,3 @@ ujsrfar:
 .include "kernsup.inc"
 
 	.byte 0, 0, 0, 0 ; signature
-
-	.word banked_nmi ; nmi
-	.word $ffff ; reset
-	.word banked_irq

--- a/keymap/vectors.s
+++ b/keymap/vectors.s
@@ -1,6 +1,0 @@
-.include "banks.inc"
-
-.segment "VECTORS"
-	.word banked_nmi
-	.word $ffff
-	.word banked_irq


### PR DESCRIPTION
Since the hardware now resets ROM bank to 0 on interrupts. Putting vectors in every ROM banks isn't needed now. Also, to keep RAM handlers useful (users can put a custom low-latency handler here 😉), IRQ vectors in bank 0 now points directly to these handlers.