### PR TITLE
[AUDIO] fix bad volume logic in psg_write

### DIFF
--- a/audio/psg.s
+++ b/audio/psg.s
@@ -300,14 +300,19 @@ loop2:
 
 	sta psgtmp1
 
+	txa
+	lsr
+	lsr
+	tax
+
 	; Shadow the raw value
 	tya
 	and #$3F
-	sta psg_volshadow,y
+	sta psg_volshadow,x
 
 	; Apply attenuation
 	sec
-	sbc psg_atten,y
+	sbc psg_atten,x
 	bpl :+
 	lda #$00
 :	ora psgtmp1


### PR DESCRIPTION
There was some horrendously wrong logic here. This function has not been well-exercised until now.

Y was the volume value, not the PSG voice.  Let's reuse X for the voice, which is the register value / 4