### PR TITLE
Always enable VBATEN on exit from control panel

### DIFF
--- a/util/control.s
+++ b/util/control.s
@@ -452,7 +452,15 @@ exe5:	cmp #5          ;save_menu
 	jmp save_menu
 exe6:	cmp #6          ;exit to basic
 	bne exe7
-	lda #147        ;clear the screen
+
+	ldx #rtc_address	;Enable battery backup, bit 3 (VBATEN) of RTC internal address 0x03
+	ldy #3
+	jsr i2c_read_byte
+	bcs :+
+	ora #8
+	jsr i2c_write_byte
+
+:	lda #147        ;clear the screen
 	jsr bsout
 	rts
 exe7:	jmp main_menu   ;we should never end up here.


### PR DESCRIPTION
Does what it says in the header :-)

Tested on my hardware with the following procedure:
- PSU disconnected and backup battery removed for 5 minutes
- Backup battery reinstalled
- Computer booted, and control panel (MENU) started. I only changed the keyboard layout and stored that to NVRAM0 before exiting the control panel. The date/time was not set or started.
- PSU disconnected for 5 minutes (battery still installed)
- Booted the computer again. Keyboard layout fetched successfully from NVRAM.