### PR TITLE
[BASIC] enhance BASIC to properly reread the top of memory from the kernal when it changes

### DIFF
--- a/bannex/basic-declare.s
+++ b/bannex/basic-declare.s
@@ -88,7 +88,7 @@ strend	.res 2           ;$31end of storage in use.
                          ;    or simple variable is encountered.
                          ;    set to [vartab] by "clearc".
 fretop	.res 2           ;$33 top of string free space
-.assert * = $03E9, error, "cc65 depends on MEMSIZ = $03E9, change with caution"
+; This instance of `memsiz` is deprecated, and BASIC should now be querying the kernal via `memtop` instead
 memsiz	.res 2           ;$37 highest location in memory
 
 ; --- line numbers and textual pointers ---:

--- a/bannex/splash.s
+++ b/bannex/splash.s
@@ -74,11 +74,13 @@ initm3:
 	clc
 	jsr plot
 
-	lda memsiz
+	sec
+	jsr memtop
+	txa
 	sec
 	sbc txttab
 	tax
-	lda memsiz+1
+	tya
 	sbc txttab+1
 	jsr numout
 
@@ -124,11 +126,13 @@ inib40: ; screen is smaller than 40, use compact banner
 	clc
 	jsr plot
 
-	lda memsiz
+	sec
+	jsr memtop
+	txa
 	sec
 	sbc txttab
 	tax
-	lda memsiz+1
+	tya
 	sbc txttab+1
 	jsr numout
 

--- a/basic/code14.s
+++ b/basic/code14.s
@@ -181,8 +181,11 @@ garbag	ldx #errom
 	sta garbfl
 	pla
 	bne tryag2
-garba2	ldx memsiz
-	lda memsiz+1
+garba2	sec
+	jsr memtop
+	stx memsiz
+	tya
+	sta memsiz+1
 fndvar	stx fretop
 	sta fretop+1
 	ldy #0

--- a/basic/code2.s
+++ b/basic/code2.s
@@ -196,9 +196,9 @@ runc	jsr stxtpt
 clear	bne stkrts
 clearc	jsr ccall       ;moved for v2 orig for rs-232
 cleart	sec
-	jsr $ff99
+	jsr memtop
 	txa
-	sta memsiz      ;entry for open & close memsiz changes
+	sta memsiz
 	sty memsiz+1
 	sta fretop
 	sty fretop+1

--- a/basic/code2.s
+++ b/basic/code2.s
@@ -195,8 +195,11 @@ runc	jsr stxtpt
 	lda #0
 clear	bne stkrts
 clearc	jsr ccall       ;moved for v2 orig for rs-232
-cleart	lda memsiz      ;entry for open & close memsiz changes
-	ldy memsiz+1
+cleart	sec
+	jsr $ff99
+	txa
+	sta memsiz      ;entry for open & close memsiz changes
+	sty memsiz+1
 	sta fretop
 	sty fretop+1
 	lda vartab

--- a/basic/code26.s
+++ b/basic/code26.s
@@ -1,12 +1,6 @@
 ;most references to kernal are defined here
 ;
-erexit	cmp #$f0        ;check for special case
-	bne erexix
-; top of memory has changed
-	sty memsiz+1
-	stx memsiz
-	jmp cleart      ;act as if he typed clear
-erexix	tax             ;set termination flags
+erexit	tax             ;set termination flags
 	bne erexiy
 	ldx #erbrk      ;break error
 erexiy	jmp error       ;normal error

--- a/basic/declare.s
+++ b/basic/declare.s
@@ -126,7 +126,7 @@ strend	.res 2           ;$31end of storage in use.
                          ;    or simple variable is encountered.
                          ;    set to [vartab] by "clearc".
 fretop	.res 2           ;$33 top of string free space
-.assert * = $03E9, error, "cc65 depends on MEMSIZ = $03E9, change with caution"
+; This instance of `memsiz` is deprecated, and BASIC should now be querying the kernal via `memtop` instead
 memsiz	.res 2           ;$37 highest location in memory
 
 ; --- line numbers and textual pointers ---:

--- a/basic/token2.s
+++ b/basic/token2.s
@@ -118,6 +118,7 @@ reslst3
 	.byt "LINPU", 'T' + $80
 	.byt "BINPUT", '#' + $80
 	.byt "HEL", 'P' + $80
+	.byt "BANNE", 'R' + $80
 
 	; add new statements before this line
 

--- a/basic/tokens.s
+++ b/basic/tokens.s
@@ -139,6 +139,7 @@ stmdsp2	; statements
 	.word linput-1
 	.word binputn-1
 	.word help-1
+	.word banner-1
 
 	; functions
 ptrfunc	.word vpeek

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -1074,6 +1074,9 @@ help:
 	bannex_call bannex_help
 	rts
 
+banner:
+	bannex_call bannex_splash
+	rts
 
 ; BASIC's entry into jsrfar
 .setcpu "65c02"

--- a/kernal/cbm/memory.s
+++ b/kernal/cbm/memory.s
@@ -15,6 +15,7 @@
 .segment "KVAR"
 
 memstr	.res 2           ; start of memory
+.assert * = $0259, error, "cc65 depends on MEMSIZ = $0259, change with caution"
 memsiz	.res 2           ; top of memory
 rambks	.res 1           ; X16: number of ram banks (0 means 256)
 


### PR DESCRIPTION
In order to make it easier to withdraw memory from being available to BASIC, enhance the clear routine (CLR, RUN, etc) to reread the values from the kernal.

This also adds the BANNER command.  There'll be another PR later on that enhances the AUTOBOOT.X16 saved from the control panel to use it.