### PR TITLE
Backup and restore monitor zero page usage

### DIFF
--- a/cfg/monitor-x16.cfgtpl
+++ b/cfg/monitor-x16.cfgtpl
@@ -2,7 +2,6 @@ MEMORY {
 	#include "x16.cfginc"
 
 	L0220:    start = $0220, size = $0039; # overlaps with top end of BASIC input line only
-
 	BANK5:      start = $C000, size = $3B00, fill=yes, fillval=$AA;
 	KSUP_CODE2: start = $FB00, size = $03A8, fill=yes, fillval=$AA;
 	KSUP_VEC2:  start = $FEA8, size = $0158, fill=yes, fillval=$AA;
@@ -17,4 +16,5 @@ SEGMENTS {
 	monitor_ram_code: load = BANK5, run = L0220, type = ro, define = yes;
 	KSUP_CODE2:       load = KSUP_CODE2, type = ro;
 	KSUP_VEC2:        load = KSUP_VEC2,  type = ro;
+	MONBACK:          load = MONBACK, type = bss;
 }

--- a/cfg/x16.cfginc
+++ b/cfg/x16.cfginc
@@ -41,7 +41,8 @@ BVARS:    start = $03D3, size = $002D; # BASIC
 KEYMAP:   start = $A000, size = $0800; # the current keyboard mapping table
 KVARSB0:  start = $A800, size = $0400; # there is some space free here
 VECB0:    start = $AC00, size = $0020; # for misc vectors, stable addresses
-BVARSB0:  start = $AD00, size = $00C0; # BASIC expansion variables, few used
+BVARSB0:  start = $AD00, size = $00B0; # BASIC expansion variables, few used
+MONBACK:  start = $ADB0, size = $0010; # MONITOR zero page backup buffer
 AUDIOBSS: start = $ADC0, size = $0040; # audio bank scratch space and misc state
 BAUDIO:   start = $AE00, size = $0100; # YM2151 shadow for audio routines
 DOSDAT:   start = $B000, size = $0F00; # there is some space free here, too


### PR DESCRIPTION
Hi,

This takes a backup of zero page addresses used by the monitor and restores them on exit, partly solving issue #111.

It works fine if you exit the monitor with the .X command. It will not work if you reset the computer. I'm not sure this is a good idea - or good enough an implementation. Marking it as draft.