### PR TITLE
Prevent OLD from loading AUTOBOOT.X16

### DIFF
--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -265,7 +265,7 @@ old1	lda txttab+1
 	lda index+1
 	adc #0
 	sta vartab+1
-	jmp init2
+	jmp ready
 
 ; ----------------------------------------------------------------
 ; XXX This is very similar to the code in MONITOR. When making

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -265,6 +265,8 @@ old1	lda txttab+1
 	lda index+1
 	adc #0
 	sta vartab+1
+	ldx #stkend-256 ;set up end of stack
+	txs
 	jmp ready
 
 ; ----------------------------------------------------------------


### PR DESCRIPTION
My first attempt at fixing this would leak memory on stack.
This fix ensures the stack pointer is reset in the same way as is done in the init2 function.