### PR TITLE
[KERNAL] Handle VERA 0.1.1 incompatibility with FX preserve

### DIFF
--- a/kernal/drivers/x16/screen.s
+++ b/kernal/drivers/x16/screen.s
@@ -598,12 +598,17 @@ screen_save_state:
 	ply
 	lda VERA_CTRL
 	pha
-	; Begin temp code to support old vera
+	; Begin temp code to support old vera, must be 0.3.x or higher
 	lda #%01111110
 	sta VERA_CTRL
 	lda $9f29
 	cmp #'V'
 	bne :+
+	lda $9f2a
+	bne :+
+	lda $9f2b
+	cmp #$03
+	bcc :+
 	; End temp code to support old vera
 	lda #%00000100
 	sta VERA_CTRL
@@ -640,6 +645,11 @@ screen_restore_state:
 	lda $9f29
 	cmp #'V'
 	bne :+
+	lda $9f2a
+	bne :+
+	lda $9f2b
+	cmp #$03
+	bcc :+
 	; End temp code to support old vera
 	lda #%00000100
 	sta VERA_CTRL


### PR DESCRIPTION
After looking at the Verilog, I see that DCSEL > 1 means DCSEL == 1.

This makes VERA 0.1.1 incompatible with FX register preserve/restore.

This (temporary) change excludes VERA < 0.3.x