### PR TITLE
[AUDIO] add new YM variant detect routine (OPM/OPP)

### DIFF
--- a/audio/main.s
+++ b/audio/main.s
@@ -86,11 +86,26 @@
 .import bas_fmchordstring
 .import bas_psgchordstring
 
+; imports from memory.s
+.import ym_chip_type
+
 .segment "CODE"
 .proc audio_init: near
 	jsr ym_init
 	jsr psg_init
 	jmp ym_loaddefpatches
+.endproc
+
+ram_bank = $00
+
+.proc ym_get_chip_type: near
+	ldx ram_bank
+	phx
+	stz ram_bank
+	lda ym_chip_type
+	plx
+	stx ram_bank
+	rts
 .endproc
 
 .segment "API"
@@ -149,3 +164,4 @@
 	jmp ym_getpan             ; $C09C
 	jmp audio_init            ; $C09F
 	jmp psg_write_fast        ; $C0A2
+	jmp ym_get_chip_type      ; $C0A5

--- a/audio/memory.s
+++ b/audio/memory.s
@@ -28,6 +28,8 @@
 .export audio_prev_bank
 .export audio_bank_refcnt
 
+.export ym_chip_type
+
 ; declare 3 bytes of ZP space for audio routines
 .segment "ZPAUDIO": zeropage
 	azp0:   .res 2  ; 16bit pointer (in the style of r0, r0L, r0H in ABI)
@@ -73,6 +75,9 @@
 	; shared (for bank mgmt)
 	audio_bank_refcnt: .res 1
 	audio_prev_bank: .res 1	
+
+	; for chip detection
+	ym_chip_type: .res 1
 
 ; YM2151 is write-only. The library will keep a RAM shadow of writes in order
 ; to facilitate functionalities like modifying the active values of the chip.

--- a/bannex/help.s
+++ b/bannex/help.s
@@ -1,9 +1,13 @@
 .include "kernal.inc"
 .include "banks.inc"
+.include "audio.inc"
 .include "io.inc"
+
+.import bajsrfar
 
 .importzp poker
 .export help
+
 
 uc_address = $42
 
@@ -144,10 +148,37 @@ check_smc:
 	lda #13
 	jsr bsout
 
-	bra final
+	bra ym2151
 smc_unknown:
 	jsr printstring
 	.byte "UNKNOWN FIRMWARE",13,0
+
+
+ym2151:
+	jsr printstring
+	.byte "YM VARIANT: ",0
+
+	jsr bajsrfar
+	.word ym_get_chip_type
+	.byte BANK_AUDIO
+
+	cmp #$01
+	beq ym_isopp
+	cmp #$02
+	beq ym_isopm
+
+	jsr printstring
+	.byte "UNKNOWN",13,0
+	bra final
+
+ym_isopm:
+	jsr printstring
+	.byte "YM2151 (OPM)",13,0
+	bra final
+
+ym_isopp:
+	jsr printstring
+	.byte "YM2164 (OPP)",13,0
 
 final:
 	jsr printstring

--- a/inc/audio.inc
+++ b/inc/audio.inc
@@ -54,3 +54,4 @@ ym_getatten           = $C099
 ym_getpan             = $C09C
 audio_init            = $C09F
 psg_write_fast        = $C0A2
+ym_get_chip_type      = $C0A5


### PR DESCRIPTION
This routine inside of `ym_init` inhibits IRQs, and sets Timer A and Timer B on the YM chip with values such that Timer B expires first on OPM and Timer A expires first on OPP, loads the timers while enabling IRQs, waits until the status byte shows a value, then saves that value.  If there is no functioning YM chip, the ym_write will likely fail on the busy flag timeout in `ym_write` or the 65536-iteration timeout will be exhausted.

At the end  of the section, the timer/IRQ flags are cleared and the previous state of the processor flags is restored.

Since `ym_init` is run in the KERNAL init routine, this detection is done at poweron.

`ym_get_chip_type` in the Audio API will return the detected chip type, which applications and music playback libraries can use to detect which chip is installed.

The BASIC `HELP` command will output the value found from the detection for convenient display.