### PR TITLE
[BASIC] make DOS command directory listings sane while in PETSCII mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,7 +471,7 @@ $(BUILD_DIR)/geos.bin: $(GEOS_OBJS) $(GEOS_DEPS) $(CFG_DIR)/geos-$(MACHINE).cfg
 # Bank 4 : BASIC
 $(BUILD_DIR)/basic.bin: $(GIT_SIGNATURE) $(BASIC_OBJS) $(BASIC_DEPS) $(CFG_DIR)/basic-$(MACHINE).cfg
 	@mkdir -p $$(dirname $@)
-	$(LD) -C $(CFG_DIR)/basic-$(MACHINE).cfg $(BASIC_OBJS) -o $@ -m $(BUILD_DIR)/basic.map -Ln $(BUILD_DIR)/basic.sym `${BUILD_DIR}/../../findsymbols ${BUILD_DIR}/kernal.sym shflag`
+	$(LD) -C $(CFG_DIR)/basic-$(MACHINE).cfg $(BASIC_OBJS) -o $@ -m $(BUILD_DIR)/basic.map -Ln $(BUILD_DIR)/basic.sym `${BUILD_DIR}/../../findsymbols ${BUILD_DIR}/kernal.sym shflag mode`
 	./scripts/relist.py $(BUILD_DIR)/basic.map $(BUILD_DIR)/basic
 
 # Bank 5 : MONITOR

--- a/basic/basic.s
+++ b/basic/basic.s
@@ -1,5 +1,7 @@
 .feature labels_without_colons
+; kernal syms
 .import shflag
+.import mode
 
 .include "banks.inc"
 .include "kernal.inc"

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -442,6 +442,7 @@ disk_dir
 	lda #' '
 	jsr bsout       ;print space  (to match loaded directory display)
 
+	ldy #0
 @d30	jsr basin       ;read & print filename & filetype
 	beq @d40        ;...branch if eol
 	pha
@@ -450,14 +451,45 @@ disk_dir
 	pla
 	cpx #0
 	bne disk_done   ;...branch if error
+	bit mode
+	bvs @d30out     ; ISO mode
+	cmp #$22
+	beq @d30qtsw    ; quotation mark
+	cpy #0
+	beq @d30out     ; not inside of quotes
+	cmp #$20
+	bcc @d30ques    ; unprintable, show ? 
+	cmp #$60
+	bcc @d30out     ; is unshifted character
+	cmp #$80
+	bcc @d30sub20   ; shifted character, subtract $20
+	cmp #$a0
+	bcc @d30ques    ; unprintable, show ?
+	cmp #$e0
+	bcs @d30ques    ; unprintable, show ?
+	bra @d30out     ; the rest are valid PETSCII
+@d30sub20
+	sec
+	sbc #$20
+@d30out
 	jsr bsout
-	bcc @d30        ;...loop always
+	bra @d30
 
 @d40	jsr crdo        ;start a new line
 	jsr stop
 	beq disk_done   ;...branch if user hit STOP
 	ldy #2
-	bne @d20        ;...loop always
+	bra @d20
+@d30qtsw ; toggle y between 0 and 1 to indicate whether we're inside quotes
+	cpy #0
+	beq :+
+	dey
+	dey
+:	iny
+	bra @d30out
+@d30ques
+	lda #'?'
+	bra @d30out
 
 disk_done
 	jsr clrch


### PR DESCRIPTION
This change makes it so getting directory listings with the `DOS` command:
- turns lowercase ASCII into unshifted PETSCII
- turns unprintable characters and duplicated screen codes into the ? character
- leaves the remaining PETSCII alone

This will help the majority of users on case-insensitive filesystems access lowercase filenames w/o getting in the way.

Caveat: this has the potential to confuse users on case-sensitive filesystems, mainly on Linux, while using HostFS.  They likely would not have been able to navigate to the lowercase names anyway, but now that the names will show up in uppercase, there will be a new source of confusion why they cannot be loaded.