### PR TITLE
[KERNAL] handle differing h/v mouse scaling based on screen mode

### DIFF
--- a/kernal/drivers/x16/ps2mouse.s
+++ b/kernal/drivers/x16/ps2mouse.s
@@ -52,10 +52,13 @@ _mouse_config:
 	beq @skip
 
 	; scale
-	lda #1
-	cpx #40
-	bne :+
-	lda #2
+	lda #0
+	cpx #41
+	bcs :+
+	ora #2
+:	cpy #31
+	bcs :+
+	ora #1
 :	sta msepar ;  set scale
 	pha
 
@@ -77,12 +80,16 @@ _mouse_config:
 	rol mousemy+1
 	sta mousemy
 
-	; 320w and less: double the size
+	; 320w and less: double the width
+	; 240h and less: double the height
 	pla
-	dec
-	beq @skip2
+	and #2
+	beq :+
 	asl mousemx
 	rol mousemx+1
+:	lda msepar
+	and #1
+	beq @skip2
 	asl mousemy
 	rol mousemy+1
 @skip2:
@@ -269,33 +276,40 @@ mouse_get:
 
 _mouse_get:
 	lda msepar
-	and #$7f
-	cmp #2 ; scale
-	beq :+
-
+	and #2
+	; x scale
+	bne @x1
 	lda mousex
 	sta 0,x
 	lda mousex+1
 	sta 1,x
+@cy:
+	lda msepar
+	and #1
+	; y scale
+	bne @y1
 	lda mousey
 	sta 2,x
 	lda mousey+1
 	sta 3,x
-	bra @s1
-:
+	lda mousebt
+	rts
+@x1:
 	lda mousex+1
 	lsr
 	sta 1,x
 	lda mousex
 	ror
 	sta 0,x
+	bra @cy
+@y1:
 	lda mousey+1
 	lsr
 	sta 3,x
 	lda mousey
 	ror
 	sta 2,x
-@s1:	lda mousebt
+	lda mousebt
 	rts
 
 ; This is the Susan Kare mouse pointer


### PR DESCRIPTION
This is the rest of the fix for https://github.com/X16Community/x16-emulator/issues/133 and also addresses an annoyance that @misterblack1 had mentioned where the mouse scaling was not separate for screen modes with non-square pixels.