### PR TITLE
[KERNAL] don't clear the keyboard buffer after Ctrl delay on CHROUT scroll

### DIFF
--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -1151,7 +1151,6 @@ mlp4	nop             ;delay
 	sec
 	sbc #1
 	bne mlp4
-	jsr kbdbuf_clear
 ;
 mlp42	ldx tblx
 ;


### PR DESCRIPTION
This looks like a C64ism that is not needed.  It interferes with pasting in the emulator using Ctrl+V because the KERNAL can pick the Ctrl up as a delay, and would eat the complete keyboard buffer, losing pasted characters.