### PR TITLE
[GRAPH] initialize px/py in console_init

### DIFF
--- a/graphics/graph/console.s
+++ b/graphics/graph/console.s
@@ -75,6 +75,10 @@ console_init:
 	stz inbufidx
 	stz override_height
 	stz override_height+1
+	stz px
+	stz px+1
+	stz py
+	stz py+1
 
 	LoadW r0, 0
 	jsr console_set_paging_message


### PR DESCRIPTION
These variables were never initialized and bad behavior ensued when the emulator defaulted to randomized RAM.  The linked issue fails similarly on hardware before this change.

Closes #152 