### PR TITLE
[KERNAL] set mouse pointer to center of screen when activating

### DIFF
--- a/kernal/drivers/x16/ps2mouse.s
+++ b/kernal/drivers/x16/ps2mouse.s
@@ -3,6 +3,8 @@
 ;----------------------------------------------------------------------
 ; (C)2019 Michael Steil, License: 2-clause BSD
 
+.macpack longbranch
+
 .include "banks.inc"
 .include "io.inc"
 .include "regs.inc"
@@ -49,7 +51,7 @@ mouse_config:
 _mouse_config:
 	pha
 	cpx #0
-	beq @skip
+	jeq @skip
 
 	; scale
 	lda #0
@@ -95,6 +97,20 @@ _mouse_config:
 @skip2:
 	DecW mousemx
 	DecW mousemy
+	; center the pointer
+	lda mousemx+1
+	lsr
+	sta mousex+1
+	lda mousemx
+	ror
+	sta mousex
+
+	lda mousemy+1
+	lsr
+	sta mousey+1
+	lda mousemy
+	ror
+	sta mousey
 
 @skip:
 	pla


### PR DESCRIPTION
When deactivating the mouse in a large screen resolution and reactivating it in a lower resolution, the mouse pointer could activate while out of bounds.  Reset the pointer to the center of the screen to avoid this.