### PR TITLE
[DOS] replace commas in FAT32 filenames with '?'

### DIFF
--- a/dos/match.s
+++ b/dos/match.s
@@ -96,6 +96,11 @@ filename_char_ucs2_to_internal:
 	cpx #$be ; U00BE '¾'
 	beq @unsupported
 
+	; characters that are allowed in VFAT filenames 
+	; but not in CMDR-DOS
+	cpx #$2c ; U002C ','
+	beq @unsupported
+	
 	; codes where ISO-8859-1 == ISO-8859-15
 	txa
 	rts


### PR DESCRIPTION
Characters in filenames that are incompatible with CMDR-DOS (including those not in ISO-8859-15) are replaced with `'?'`.  Add comma `','` to that list