### PR TITLE
[CHARSET] restore butterfly glyph to primary ISO set

### DIFF
--- a/charset/iso-8859-15.s
+++ b/charset/iso-8859-15.s
@@ -1751,14 +1751,14 @@
 .byte %00000000
 .byte %00000000
 
-; $ad ­
-.byte %00000000
-.byte %00000000
-.byte %00000000
-.byte %00000000
+; nonprintable shift-hypen "SHY" (repurposed for Commander X16 logo)
+.byte %11000011
+.byte %11100111
 .byte %01111110
-.byte %00000000
-.byte %00000000
+.byte %00111100
+.byte %00011000
+.byte %01111110
+.byte %01100110
 .byte %00000000
 
 ; $ae ®


### PR DESCRIPTION
This reverts its replacement inadvertently caused by #84 