### PR TITLE
[MONITOR] populate stack frame so that monitor's view of the registers at BRK are correct

### DIFF
--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -210,6 +210,9 @@ __jmpfr:
 .assert * = irq, error, "irq must be at specific address"
 .export __irq
 __irq:
+	; If this stack preserve order is ever changed, check
+	; and update the MONITOR entry code as it makes assumptions
+	; about what happens here upon BRK.
 	pha
 	lda rom_bank    ;save ROM bank
 	pha

--- a/monitor/monitor.s
+++ b/monitor/monitor.s
@@ -207,13 +207,11 @@ monitor:
 @end:
 
 	php
-	pha
 	sei
 	lda #<brk_entry
 	sta cbinv
 	lda #>brk_entry
 	sta cbinv + 1 ; BRK vector
-	pla
 	plp
 	
 	bra brk_entry2


### PR DESCRIPTION
This makes the monitor substantially more useful upon a BRK instruction.