### PR TITLE
[BASIC] new EXEC command and support

### DIFF
--- a/bannex/basic-declare.s
+++ b/bannex/basic-declare.s
@@ -124,3 +124,6 @@ basic_fa .res 1          ;    default device address
     rencur: .res 2
     rentmp: .res 2
     rentmp2: .res 2
+    exec_flag: .res 1
+    exec_addr: .res 2
+    exec_bank: .res 1

--- a/basic/code1.s
+++ b/basic/code1.s
@@ -37,17 +37,80 @@ readyx	lda #<reddy
 
 main	jsr clear_4080_flag
 	jmp (imain)
-nmain	jsr inlin
-	stx txtptr
+nmain	stz ram_bank
+	lda exec_flag
+	beq @1
+	lda exec_addr
+	sta poker
+	lda exec_addr+1
+	sta poker+1
+	lda exec_bank
+	sta ram_bank
+	ldy #1
+	ldx #0
+@e0	lda (poker)
+	pha
+	inc poker
+	bne :+
+	inc poker+1
+	lda poker+1
+	cmp #$c0
+	bcc :+
+	sbc #$20
+	sta poker+1
+	inc ram_bank
+:	pla
+	beq @e1
+	cmp #10
+	beq @e2
+	cmp #13
+	beq @e2
+	sta buf,x
+	jsr bsout
+	inx
+	cpx #buflen
+	bcc @e0
+	bra @esl
+@e1	ldy #0
+@e2	lda #13
+	jsr bsout
+	stz buf,x
+	lda ram_bank
+	stz ram_bank
+	sty exec_flag
+	lda poker
+	sta exec_addr
+	lda poker+1
+	sta exec_addr+1
+	jsr stop
+	bne :+
+	ldx #erbrk
+	bra @err
+:	lda crambank
+	sta ram_bank
+	ldx #<zz5
+	ldy #>zz5
+	bra @2
+@esl	ldx #errls
+@err	stz ram_bank
+	stz exec_flag
+	lda crambank
+	sta ram_bank
+	jmp error
+@1	lda crambank
+	sta ram_bank
+	jsr inlin
+@2	stx txtptr
 	sty txtptr+1
 	jsr chrget
 	tax
-	beq main
+	beq @3
 	ldx #255
 	stx curlin+1
 	bcc main1
 	jsr crunch
 	jmp gone
+@3	jmp main
 main1	jsr linget
 	jsr crunch
 	sty count

--- a/basic/code1.s
+++ b/basic/code1.s
@@ -51,15 +51,15 @@ nmain	stz ram_bank
 @e0	lda (poker)
 	pha
 	inc poker
-	bne :+
-	inc poker+1
+	bne @eb
 	lda poker+1
+	inc
 	cmp #$c0
-	bcc :+
+	bcc @ea
 	sbc #$20
-	sta poker+1
 	inc ram_bank
-:	pla
+@ea	sta poker+1
+@eb	pla
 	beq @e1
 	cmp #10
 	beq @e2
@@ -78,25 +78,20 @@ nmain	stz ram_bank
 	lda ram_bank
 	stz ram_bank
 	sty exec_flag
+	sta exec_bank
 	lda poker
 	sta exec_addr
 	lda poker+1
 	sta exec_addr+1
 	jsr stop
-	bne :+
+	bne @e3
 	ldx #erbrk
 	bra @err
-:	lda crambank
+@e3	lda crambank
 	sta ram_bank
 	ldx #<zz5
 	ldy #>zz5
 	bra @2
-@esl	ldx #errls
-@err	stz ram_bank
-	stz exec_flag
-	lda crambank
-	sta ram_bank
-	jmp error
 @1	lda crambank
 	sta ram_bank
 	jsr inlin
@@ -111,6 +106,12 @@ nmain	stz ram_bank
 	jsr crunch
 	jmp gone
 @3	jmp main
+@esl	ldx #errls
+@err	stz ram_bank
+	stz exec_flag
+	lda crambank
+	sta ram_bank
+	jmp error
 main1	jsr linget
 	jsr crunch
 	sty count

--- a/basic/code26.s
+++ b/basic/code26.s
@@ -172,7 +172,9 @@ cld50	jsr $ffb7       ;read status
 	ldx #erload
 cld55	jmp error
 ;
-cld60	lda eormsk
+cld60	stx sxreg   ; save [B]LOAD addr so BASIC can inspect
+	sty syreg
+	lda eormsk
 	bne cld20
 	lda txtptr+1
 	cmp #bufpag     ;direct?

--- a/basic/declare.s
+++ b/basic/declare.s
@@ -181,3 +181,6 @@ usrpok	.res 3           ;$0310 user function dispatch
     rencur: .res 2
     rentmp: .res 2
     rentmp2: .res 2
+    exec_flag: .res 1
+    exec_addr: .res 2
+    exec_bank: .res 1

--- a/basic/init.s
+++ b/basic/init.s
@@ -10,6 +10,10 @@ panic	jsr clschn      ;warm start basic...
 	lda #0          ;clear channels
 	sta channl
 	jsr stkini      ;restore stack
+	lda ram_bank
+	stz ram_bank
+	stz exec_flag
+	sta ram_bank
 	cli             ;enable irq's
 
 ready	ldx #$80
@@ -24,6 +28,7 @@ init	jsr initv       ;go init vectors
 	jsr initms      ;go print initilization messages
 	stz ram_bank
 	stz crombank     ;set default value for BANK statement (ROM)
+	stz exec_flag
 	ldx #1
 	stx crambank     ;set default value for BANK statement (RAM)
 	stx ram_bank

--- a/basic/token2.s
+++ b/basic/token2.s
@@ -119,6 +119,7 @@ reslst3
 	.byt "BINPUT", '#' + $80
 	.byt "HEL", 'P' + $80
 	.byt "BANNE", 'R' + $80
+	.byt "EXE", 'C' + $80
 
 	; add new statements before this line
 

--- a/basic/tokens.s
+++ b/basic/tokens.s
@@ -140,7 +140,7 @@ stmdsp2	; statements
 	.word binputn-1
 	.word help-1
 	.word banner-1
-
+	.word exec-1
 	; functions
 ptrfunc	.word vpeek
 	.word mx

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -1105,6 +1105,28 @@ banner:
 	bannex_call bannex_splash
 	rts
 
+exec:
+	stz ram_bank
+	jsr frmadr
+	lda crambank
+	sta exec_bank
+	lda poker
+	sta exec_addr
+	lda poker+1
+	sta exec_addr+1
+	jsr chrgot
+	beq @1
+	jsr chkcom
+	jsr getbyt
+	stx exec_bank
+@1:
+	lda #1
+	sta exec_flag
+	lda crambank
+	sta ram_bank
+	rts
+
+
 ; BASIC's entry into jsrfar
 .setcpu "65c02"
 .export bjsrfar


### PR DESCRIPTION
EXEC will take a memory location containing a series of BASIC immediate mode commands.  While EXEC is active, commands will be fed line by line as long as immediate/direct mode is active.  EXEC mode stops when
* it reads a null character ($00) from memory
* it reads a line that exceeds BASIC's max line length (80)
* the stop key is pressed
* basic is cold or warm started

This command can be used as part of an approach to get tokenized BASIC from plain text data.

This PR also augments `BLOAD` to feed the end load address into the X/Y SYS communication memory locations, so that BASIC programs can programmatically retrieve it.  This should help other cases of BLOAD where a BASIC program doesn't have foreknowledge of the exact sizes of the files to be loaded.

Here's a PoC for the EXEC command that loads a file

```basic
10 BLOAD"SCRIPT.BAS",8,2,$A000
20 REM IMMEDIATELY AFTER BLOAD, $00 CONTAINS END BANK FOR LOAD
30 REM AND X/Y SYS COMMUNICATION REGISTERS CONTAIN THE END LOAD ADDRESS
40 BK=PEEK(0):EA=(PEEK($30E)*256)+PEEK($30D)
50 PRINT "END BANK:"+STR$(BK)+" END ADDRESS: $"+HEX$(EA)
60 BANK BK:POKE EA,0 : REM NULL-TERMINATE SCRIPT IN THE END BANK
70 EXEC $A000,2 : REM EXEC SCRIPT IN THE START BANK
80 REM EXEC WILL BEGIN ONCE BASIC RETURNS TO IMMEDIATE MODE
90 NEW : REM START EXEC WITH A CLEAN SLATE
```