### PR TITLE
Intellimouse support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ $(BUILD_DIR)/fat32.bin: $(FAT32_OBJS) $(FAT32_DEPS) $(CFG_DIR)/fat32-x16.cfg
 # Bank 4 : BASIC
 $(BUILD_DIR)/basic.bin: $(GIT_SIGNATURE) $(BASIC_OBJS) $(BASIC_DEPS) $(CFG_DIR)/basic-x16.cfg
 	@mkdir -p $$(dirname $@)
-	$(LD) -C $(CFG_DIR)/basic-x16.cfg $(BASIC_OBJS) -o $@ -m $(BUILD_DIR)/basic.map -Ln $(BUILD_DIR)/basic.sym `${BUILD_DIR}/../../findsymbols ${BUILD_DIR}/kernal.sym shflag mode`
+	$(LD) -C $(CFG_DIR)/basic-x16.cfg $(BASIC_OBJS) -o $@ -m $(BUILD_DIR)/basic.map -Ln $(BUILD_DIR)/basic.sym `${BUILD_DIR}/../../findsymbols ${BUILD_DIR}/kernal.sym shflag mode wheel`
 	./scripts/relist.py $(BUILD_DIR)/basic.map $(BUILD_DIR)/basic
 
 # Bank 5 : MONITOR

--- a/basic/token2.s
+++ b/basic/token2.s
@@ -135,7 +135,7 @@ reslst3
 	.byt "POINTE", 'R' + $80
 	.byt "STRPT", 'R' + $80
 	.byt "RPT", '$' + $80
-	.byt "M", 'W' + $80
+	.byt "MWHEE", 'L' + $80
 
 	; add new functions before this line
 	.byt 0

--- a/basic/token2.s
+++ b/basic/token2.s
@@ -135,6 +135,7 @@ reslst3
 	.byt "POINTE", 'R' + $80
 	.byt "STRPT", 'R' + $80
 	.byt "RPT", '$' + $80
+	.byt "M", 'W' + $80
 
 	; add new functions before this line
 	.byt 0

--- a/basic/tokens.s
+++ b/basic/tokens.s
@@ -153,6 +153,7 @@ ptrfunc	.word vpeek
 	.word pointer
 	.word strptr
 	.word rptd
+	.word mw
 ptrend
 num_esc_statements = (ptrfunc - stmdsp2) / 2
 num_esc_functions = (ptrend - ptrfunc) / 2

--- a/basic/tokens.s
+++ b/basic/tokens.s
@@ -153,7 +153,7 @@ ptrfunc	.word vpeek
 	.word pointer
 	.word strptr
 	.word rptd
-	.word mw
+	.word mwheel
 ptrend
 num_esc_statements = (ptrfunc - stmdsp2) / 2
 num_esc_functions = (ptrend - ptrfunc) / 2

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -538,7 +538,7 @@ mb:
 	jmp sngflt
 
 ;***************
-mw:
+mwheel:
 	jsr chrget
 	ldx #fac
 	jsr mouse_get

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -1,4 +1,4 @@
-
+.import wheel
 
 VERA_BASE = $9F20
 
@@ -513,6 +513,7 @@ mx:
 	jsr chrget
 	ldx #fac
 	jsr mouse_get
+	jsr restore_wheel
 	lda fac+1
 	ldy fac
 	jmp givayf0
@@ -522,6 +523,7 @@ my:
 	jsr chrget
 	ldx #fac
 	jsr mouse_get
+	jsr restore_wheel
 	lda fac+3
 	ldy fac+2
 	jmp givayf0
@@ -532,7 +534,26 @@ mb:
 	ldx #fac
 	jsr mouse_get
 	tay
+	jsr restore_wheel
 	jmp sngflt
+
+;***************
+mw:
+	jsr chrget
+	ldx #fac
+	jsr mouse_get
+	txa
+	tay
+	jmp sngflt
+
+restore_wheel:
+	lda ram_bank
+	pha
+	stz ram_bank
+	stx wheel
+	pla
+	sta ram_bank
+	rts
 
 ;***************
 joy:

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -544,7 +544,11 @@ mw:
 	jsr mouse_get
 	txa
 	tay
-	jmp sngflt
+	bpl :+
+	lda #$ff
+	bra :++
+:	lda #$00
+:	jmp givayf0
 
 restore_wheel:
 	lda ram_bank

--- a/kernal/drivers/x16/ps2mouse.s
+++ b/kernal/drivers/x16/ps2mouse.s
@@ -17,7 +17,7 @@
 
 .import sprite_set_image, sprite_set_position
 
-.export mouse_config, mouse_scan, mouse_get
+.export mouse_config, mouse_scan, mouse_get, wheel
 
 .segment "KVARSB0"
 


### PR DESCRIPTION
Summary of changes.

Makefile:
- Imports Kernal variable wheels when building BASIC rom

BASIC:
- Adds command MW that returns the mouse wheel value
- MX, MY, and MB changed to preserve mouse wheel value

ps2mouse.s:
- The config function fetches mouse device ID, and stores it for later use by the mouse scan function
- If the mouse device ID = BAT_FAIL, no mouse is attached to the system, or the mouse init failed. In this case, the config exits without showing the mouse pointer
- The mouse scan function fetches a fourth movement packet byte if device ID is 3 or 4
- The mouse wheel movement is added to a signed 8 bit buffer ("wheel")
- The mouse get function returns the wheel value in X register. The wheel value is cleared at the same time.
- The mouse get function returns flags for extra buttons (device ID 4) in A bits 4 and 5.

There is a corresponding PR for the SMC, but not yet anything for the emulator.

The emulator will currently report 0xff when the mouse device ID is requested. The Kernal will interpret this as device 0. The mouse will work in the emulator as before, but there is not yet support for the scroll wheel or the extra buttons.

Finally, I have not got a mouse with the extra 2 buttons, and I haven't been able to test mouse device ID 4 myself.