### PR TITLE
[BASIC/BANNEX] emulate DOS wedge commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,8 +367,8 @@ $(BUILD_DIR)/util.bin: $(UTIL_OBJS) $(UTIL_DEPS) $(CFG_DIR)/util-x16.cfg
 $(BUILD_DIR)/bannex.bin: $(BANNEX_OBJS) $(BANNEX_DEPS) $(CFG_DIR)/bannex-x16.cfg
 	@mkdir -p $$(dirname $@)
 	$(LD) -C $(CFG_DIR)/bannex-x16.cfg $(BANNEX_OBJS) -o $@ -m $(BUILD_DIR)/bannex.map -Ln $(BUILD_DIR)/bannex.sym \
-	`${BUILD_DIR}/../../findsymbols ${BUILD_DIR}/basic.sym basic_fa chrgot crambank curlin facho index index1 index2 poker rencur reninc rennew renold rentmp rentmp2 txttab valtyp vartab verck` \
-	`${BUILD_DIR}/../../findsymbols ${BUILD_DIR}/basic.sym -p basic_ chkcom crdo error frefac frmadr frmevl getadr getbyt linprt` \
+	`${BUILD_DIR}/../../findsymbols ${BUILD_DIR}/basic.sym basic_fa chrgot crambank curlin eormsk facho index index1 index2 poker rencur reninc rennew renold rentmp rentmp2 txtptr txttab valtyp vartab verck` \
+	`${BUILD_DIR}/../../findsymbols ${BUILD_DIR}/basic.sym -p basic_ chkcom cld10 crdo erexit error frefac frmadr frmevl getadr getbyt linprt nsnerr6` \
 	`${BUILD_DIR}/../../findsymbols ${BUILD_DIR}/kernal.sym mode`
 	./scripts/relist.py $(BUILD_DIR)/bannex.map $(BUILD_DIR)/bannex
 

--- a/bannex/basic_far.s
+++ b/bannex/basic_far.s
@@ -9,6 +9,12 @@
 .import basic_crdo
 .export crdo
 
+.import basic_erexit
+.export erexit
+
+.import basic_cld10
+.export cld10
+
 .import basic_error
 .export error
 .export fcerr
@@ -32,60 +38,82 @@ errfc=14
 .import basic_linprt
 .export linprt
 
+.import basic_nsnerr6
+.export nsnerr6
+
 chkcom:
-    jsr bajsrfar
-    .word basic_chkcom
-    .byte BANK_BASIC
-    rts
+	jsr bajsrfar
+	.word basic_chkcom
+	.byte BANK_BASIC
+	rts
 
 crdo:
-    jsr bajsrfar
-    .word basic_crdo
-    .byte BANK_BASIC
-    rts
+	jsr bajsrfar
+	.word basic_crdo
+	.byte BANK_BASIC
+	rts
 
-fcerr:
-    ldx #errfc
-    jmp error
+cld10:
+	jsr bajsrfar
+	.word basic_cld10
+	.byte BANK_BASIC
+	rts
 
-frefac:
-    jsr bajsrfar
-    .word basic_frefac
-    .byte BANK_BASIC
-    rts
-
-frmadr:
-    jsr bajsrfar
-    .word basic_frmadr
-    .byte BANK_BASIC
-    rts
-
-frmevl:
-    jsr bajsrfar
-    .word basic_frmevl
-    .byte BANK_BASIC
-    rts
+erexit:
+	jsr bajsrfar
+	.word basic_erexit
+	.byte BANK_BASIC
+	rts
 
 error:
-    jsr bajsrfar
-    .word basic_error
-    .byte BANK_BASIC
-    rts
+	jsr bajsrfar
+	.word basic_error
+	.byte BANK_BASIC
+	rts
+
+fcerr:
+	ldx #errfc
+	jmp error
+
+frefac:
+	jsr bajsrfar
+	.word basic_frefac
+	.byte BANK_BASIC
+	rts
+
+frmadr:
+	jsr bajsrfar
+	.word basic_frmadr
+	.byte BANK_BASIC
+	rts
+
+frmevl:
+	jsr bajsrfar
+	.word basic_frmevl
+	.byte BANK_BASIC
+	rts
 
 getadr:
-    jsr bajsrfar
-    .word basic_getadr
-    .byte BANK_BASIC
-    rts
+	jsr bajsrfar
+	.word basic_getadr
+	.byte BANK_BASIC
+	rts
 
 getbyt:
-    jsr bajsrfar
-    .word basic_getbyt
-    .byte BANK_BASIC
-    rts
+	jsr bajsrfar
+	.word basic_getbyt
+	.byte BANK_BASIC
+	rts
 
 linprt:
-    jsr bajsrfar
-    .word basic_linprt
-    .byte BANK_BASIC
-    rts
+	jsr bajsrfar
+	.word basic_linprt
+	.byte BANK_BASIC
+	rts
+
+nsnerr6:
+	jsr bajsrfar
+	.word basic_nsnerr6
+	.byte BANK_BASIC
+	rts
+

--- a/bannex/main.s
+++ b/bannex/main.s
@@ -19,6 +19,7 @@ rom_bank = 1
 .import dos_getfa
 .import dos_ptstat3
 .import dos_clear_disk_status
+.import dos_chkdosw
 
 .segment "JMPTBL"
 	jmp renumber           ; $C000
@@ -31,3 +32,4 @@ rom_bank = 1
 	jmp dos_getfa          ; $C015
 	jmp dos_ptstat3        ; $C018
 	jmp dos_clear_disk_status ; $C01B
+	jmp dos_chkdosw        ; $C01E

--- a/basic/code1.s
+++ b/basic/code1.s
@@ -103,6 +103,7 @@ nmain	stz ram_bank
 	ldx #255
 	stx curlin+1
 	bcc main1
+	jsr chkdosw
 	jsr crunch
 	jmp gone
 @3	jmp main

--- a/basic/code26.s
+++ b/basic/code26.s
@@ -114,8 +114,6 @@ nsnerr6	lda verck   ;fetch the device (fa) that was used
 	lda #$0d
 	jsr bsout
 	pla             ;this will have the fa used for the save
-	sec
-	php
 	jmp ptstat3     ;part of the `dos` routine
 :	pla
 	rts

--- a/basic/declare.s
+++ b/basic/declare.s
@@ -43,7 +43,7 @@ forpnt	.res 2           ;$49 a variable's pointer for "for" loops
                          ;    and "let" statements
 lstpnt	=forpnt          ;$49 pntr to list string
 andmsk	=forpnt          ;$49 the mask used by wait for anding
-eormsk	=forpnt+1        ;$4A the mask for eoring in wait
+eormsk	:=forpnt+1        ;$4A the mask for eoring in wait
 
 ; CHRGET
 chrget	.res 6           ;$73

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -272,6 +272,15 @@ old1	lda txttab+1
 	txs
 	jmp ready
 
+chkdosw:
+	bannex_call bannex_dos_chkdosw
+	bcs @1
+	rts
+@1:
+	jsr stkini
+	jmp readyx
+
+
 ;***************
 dos:
 	bannex_call bannex_dos

--- a/inc/bannex.inc
+++ b/inc/bannex.inc
@@ -9,3 +9,4 @@ bannex_dos              = $C012
 bannex_dos_getfa        = $C015
 bannex_dos_ptstat3      = $C018
 bannex_dos_clear_disk_status = $C01B
+bannex_dos_chkdosw      = $C01E


### PR DESCRIPTION
This PR implements most of the DOS wedge shortcuts, but directly into the immediate mode interpreter loop rather than as a `chrget` replacement.

| Command | Action |
|-|-|
| `/<filename>` | Load a BASIC program into RAM |
| `%<filename>` | Load a machine language program into RAM (like `,8,1`) |
| `↑<filename>` | Load a BASIC program into RAM and then unconditionally run it |
| `←<filename>` | Save a BASIC program to disk |
| `@` | Display (and clear) the disk drive status |
| `@$` | Display the disk directory without overwriting the BASIC program in memory |
| `@#<device number>` | Change default DOS device |
| `@<command>` | Execute a disk drive command (e.g. `S0:<filename>`, `CD:<dir>`) |

Any `@` command will also work as a `>` command.

This implementation does not honor `@Q` (deactivate dos wedge)

Arguments to the leading command character (e.g. `/`, `@`) may optionally be quoted, and whitespace is ignored in between the command character and the beginning of the argument.  This allows one to move the cursor to the output of directory listings and use one of the lines as an argument to wedge type commands.