### PR TITLE
[MONITOR] move ZP usage to BASIC area, honor RAM bank separately from ROM bank, enhance register dump/read

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,8 @@ $(BUILD_DIR)/basic.bin: $(GIT_SIGNATURE) $(BASIC_OBJS) $(BASIC_DEPS) $(CFG_DIR)/
 # Bank 5 : MONITOR
 $(BUILD_DIR)/monitor.bin: $(MONITOR_OBJS) $(MONITOR_DEPS) $(CFG_DIR)/monitor-x16.cfg
 	@mkdir -p $$(dirname $@)
-	$(LD) -C $(CFG_DIR)/monitor-x16.cfg $(MONITOR_OBJS) -o $@ -m $(BUILD_DIR)/monitor.map -Ln $(BUILD_DIR)/monitor.sym `${BUILD_DIR}/../../findsymbols ${BUILD_DIR}/kernal.sym mode`
+	$(LD) -C $(CFG_DIR)/monitor-x16.cfg $(MONITOR_OBJS) -o $@ -m $(BUILD_DIR)/monitor.map -Ln $(BUILD_DIR)/monitor.sym `${BUILD_DIR}/../../findsymbols ${BUILD_DIR}/kernal.sym mode` \
+	`${BUILD_DIR}/../../findsymbols ${BUILD_DIR}/basic.sym -p basic_ linnum tempst forpnt`
 	./scripts/relist.py $(BUILD_DIR)/monitor.map $(BUILD_DIR)/monitor
 
 # Bank 6 : CHARSET

--- a/monitor/monitor.s
+++ b/monitor/monitor.s
@@ -104,16 +104,20 @@
 .import cmd_at
 .import cmd_ls
 
-zp              = $22
-zp1		= zp+0
-zp2		= zp+2
-zp3		= zp+4
-mon_fa		= zp+6
-bank		= zp+7
-f_keys_disabled	= zp+8
-tmp1		= zp+9
-tmp2		= zp+10
-bank_flags	= zp+11 ; $80: video, $40: I2C
+.importzp basic_linnum
+.importzp basic_tempst
+.importzp basic_forpnt
+
+zp1         = basic_linnum+0
+zp2         = basic_tempst+0
+zp3         = basic_tempst+2
+mon_fa      = basic_tempst+4
+bank_flags  = basic_tempst+5 ; $80: video, $40: I2C
+f_keys_disabled	= basic_tempst+6
+tmp1        = basic_tempst+7
+tmp2        = basic_tempst+8
+bank_ra     = basic_forpnt+0
+bank_ro     = basic_forpnt+1
 
 DEFAULT_BANK	:= 0
 
@@ -146,11 +150,8 @@ reg_x		:= ram_code_end + 9
 reg_y		:= ram_code_end + 10
 reg_s		:= ram_code_end + 11
 
-irq_lo		:= ram_code_end + 12
-irq_hi		:= ram_code_end + 13
-
-entry_type	:= ram_code_end + 14
-command_index	:= ram_code_end + 15 ; index from "command_names", or 'C'/'S' in EC/ES case
+entry_type	:= ram_code_end + 12
+command_index	:= ram_code_end + 13 ; index from "command_names", or 'C'/'S' in EC/ES case
 .assert command_index < $0200 + 2*40+1, error, "must not overflow KERNAL editor's buffer"
 
 .segment "monitor"
@@ -179,7 +180,7 @@ monitor:
 	pla ; jsrfar return LSB
 	pla ; jsrfar return MSB
 	pla ; caller bank
-	sta bank
+	sta bank_ro
 	; if this is a monitor entry, the PC is two-off from the BRK-induced PC
 	pla
 	clc
@@ -189,7 +190,7 @@ monitor:
 	adc #0
 	tay ; kernsup return MSB
 	; if we were called by BASIC, the caller bank will be 4
-	lda bank
+	lda bank_ro
 	cmp #BANK_BASIC
 	beq @basic
 	phy
@@ -198,7 +199,7 @@ monitor:
 	pha
 	lda reg_a
 	pha
-	lda bank
+	lda bank_ro
 	pha
 	phy
 	phx
@@ -225,7 +226,7 @@ monitor:
 	pha
 	lda $030c
 	pha
-	lda bank
+	lda bank_ro
 	pha
 	phy
 	phx
@@ -297,7 +298,11 @@ brk_entry2:
 
 	; pull off preserved rom bank
 	pla
-	sta bank
+	sta bank_ro
+
+	; set RAM bank from state at entry
+	lda ram_bank
+	sta bank_ra
 
 	pla
 	sta reg_a ; real preserved A from __irq
@@ -341,7 +346,7 @@ cmd_r:
 	bne syntax_error
 dump_registers:
 	ldx #0
-:	lda s_regs,x ; "PC	IRQ  BK AC XR YR SP NV#BDIZC"
+:	lda s_regs,x ; "PC   RA RO AC XR YR SP NV#BDIZC"
 	beq dump_registers2
 	jsr bsout
 	inx
@@ -354,16 +359,11 @@ dump_registers2:
 	lda reg_pc_lo
 	jsr print_hex_byte2 ; address lo
 	jsr print_space
-	lda irq_hi
-	jsr print_hex_byte2 ; IRQ hi
-	lda irq_lo
-	jsr print_hex_byte2 ; IRQ lo
-	jsr print_space
 	bit  bank_flags
 	bpl  :+
 	lda #'V'
 @1:	jsr bsout
-	lda bank
+	lda bank_ra
 	jsr byte_to_hex_ascii
 	tya
 	jsr bsout
@@ -372,9 +372,13 @@ dump_registers2:
 	lda #'I'
 	bne @1
 :
-	lda bank
-	jsr print_hex_byte2 ; bank
-LABEB:	ldy #0
+
+	lda bank_ra
+	jsr print_hex_byte2 ; RAM bank
+LABEB:	jsr print_space
+	lda bank_ro
+	jsr print_hex_byte2 ; ROM bank
+	ldy #0
 :	jsr print_space
 	lda registers,y
 	jsr print_hex_byte2 ; registers...
@@ -801,40 +805,44 @@ cmd_semicolon:
 	lda zp2
 	sta reg_pc_lo
 	jsr basin_if_more
-	jsr get_hex_word3
-	lda zp2
-	sta irq_lo
-	lda zp2 + 1
-	sta irq_hi
-	jsr basin_if_more ; skip upper nybble of bank
-	; XXX X16
 	jsr basin_if_more
-	cmp #'D' ; "drive"
-	bne LAE12
+	cmp #'V'
+	beq @video
+	cmp #'I'
+	beq @i2c
+	jsr get_hex_byte2
+	sta bank_ra
+@1:
 	jsr basin_if_more
-	cmp #'R'
-	bne syn_err1
-	ora #$80 ; XXX why not lda #$80?
-	bmi LAE1B ; always
-LAE12:	jsr get_hex_byte2
-	cmp #8
-	bcs syn_err1
-LAE1B:	sta bank
-	ldx #0
-LAE20:	jsr basin_if_more
 	jsr get_hex_byte
-	sta registers,x ; registers
-	inx
-	cpx #4
-	bne LAE20
+	sta bank_ro
+	jsr basin_if_more
+	jsr get_hex_byte
+	sta reg_a
+	jsr basin_if_more
+	jsr get_hex_byte
+	sta reg_x
+	jsr basin_if_more
+	jsr get_hex_byte
+	sta reg_y
+	jsr basin_if_more
+	jsr get_hex_byte
+	sta reg_s
 	jsr basin_if_more
 	jsr get_bin_byte
 	sta reg_p
 	jsr print_up
 	jmp dump_registers2
-
-syn_err1:
-	jmp syntax_error
+@i2c:
+	lda #$40
+	bra :+
+@video:
+	lda #$80
+:	sta bank_flags
+	lda #'0'
+	jsr get_hex_byte2
+	bra @1
+	
 
 ; ----------------------------------------------------------------
 ; "," - input up to three hex values
@@ -872,8 +880,9 @@ LAF06:
 	pha
 	ldx reg_x
 	ldy reg_y
-	lda bank
+	lda bank_ra
 	sta ram_bank
+	lda bank_ro
 	jmp goto_user
 
 ; ----------------------------------------------------------------
@@ -898,8 +907,9 @@ cmd_j:
 	ldy reg_y
 	lda reg_p
 	pha
-	lda bank
+	lda bank_ra
 	sta ram_bank
+	lda bank_ro
 	jmp jsr_user
 cmd_j_cont:
 	pla
@@ -1008,8 +1018,12 @@ load_byte:
 	bvs @i2c
 ; RAM
 	stx tmp1
-	ldx bank
-	lda #zp1
+	ldx bank_ra
+	lda zp1+1
+	cmp #$c0
+	bcc :+
+	ldx bank_ro
+:	lda #zp1
 	sei
 	jsr fetch
 	cli
@@ -1023,7 +1037,7 @@ load_byte:
 	lda zp1 + 1
 	adc #0
 	sta VERA_ADDR_M
-	lda bank
+	lda bank_ra
 	sta VERA_ADDR_H
 	lda VERA_DATA0
 	rts
@@ -1048,7 +1062,13 @@ store_byte:
 	stx tmp1
 	ldx #zp1
 	stx stavec
-	ldx bank
+	ldx bank_ra
+	pha
+	lda zp1+1
+	cmp #$c0
+	bcc :+
+	ldx bank_ro ; BONK RAM support
+:	pla
 	sei
 	jsr stash
 	cli
@@ -1063,7 +1083,7 @@ store_byte:
 	lda zp1 + 1
 	adc #0
 	sta VERA_ADDR_M
-	lda bank
+	lda bank_ra
 	sta VERA_ADDR_H
 	pla
 	sta VERA_DATA0
@@ -1098,17 +1118,29 @@ get_i2c_addr:
 
 ; ----------------------------------------------------------------
 ; "O" - set bank
-;	C64: * 0 to 7 map to a $01 value of $30-$37
-;	     * "D" switches to drive memory
-;	TED: * 0 to C, Shift+D and E to F map to banks 0-F
-;	     * "D" switches to drive memory
-;	X16: * 00 to FF are set as both ROM and RAM bank
+;	X16: * 00 to FF are set as ROM bank
 ; ----------------------------------------------------------------
 cmd_o:
+:	jsr basin_cmp_cr
+	beq LB33F ; without arguments: bank 0
+	cmp #' '
+	beq :-
+	jsr get_hex_byte2
+	bra store_bank
+LB33F	lda #DEFAULT_BANK
+store_bank:
+	sta bank_ro
+	jmp print_cr_then_input_loop
+
+
+; ----------------------------------------------------------------
+; "K" - set RAM bank
+; also sets video/I2C
+cmd_k:
 	lda #0
 	sta bank_flags
 :	jsr basin_cmp_cr
-	beq LB33F ; without arguments: bank 7
+	beq ck0 ; without arguments: bank 0
 	cmp #' '
 	beq :-
 	cmp #'V'
@@ -1121,11 +1153,10 @@ video_loop:
 	cmp #' '
 	beq video_loop
 	jsr hex_digit_to_nybble
-	bra		:+
+	bra	store_ram_bank
 default_video_bank:
 	lda #0
-:
-	jmp store_bank
+	bra store_ram_bank
 
 not_video:
 	cmp #'I'
@@ -1136,14 +1167,13 @@ not_video:
 
 not_i2c:
 	jsr get_hex_byte2
-	bra :+
-LB33F	lda #DEFAULT_BANK
-:
-	bra store_bank
-LB34A:	lda #$80 ; drive
-store_bank:
-	sta bank
+	bra store_ram_bank
+ck0:
+	lda #DEFAULT_BANK
+store_ram_bank:
+	sta bank_ra
 	jmp print_cr_then_input_loop
+
 
 ; ----------------------------------------------------------------
 
@@ -1503,7 +1533,7 @@ LB6AC:	jsr bsout
 
 ; ----------------------------------------------------------------
 
-s_regs: .byte	CR, "   PC  IRQ  BK AC XR YR SP NV#BDIZC", CR, 0
+s_regs: .byte	CR, "   PC  RA RO AC XR YR SP NV#BDIZC", CR, 0
 
 ; ----------------------------------------------------------------
 
@@ -1541,6 +1571,7 @@ command_index_i = <(* - command_names)
 	.byte "'"
 	.byte ";"
 	.byte "J"
+	.byte "K"
 command_names_end:
 
 function_table:
@@ -1569,6 +1600,7 @@ function_table:
 	.word cmd_singlequote-1
 	.word cmd_semicolon-1
 	.word cmd_j-1
+	.word cmd_k-1
 
 ; ----------------------------------------------------------------
 

--- a/monitor/monitor.s
+++ b/monitor/monitor.s
@@ -1153,6 +1153,7 @@ video_loop:
 	cmp #' '
 	beq video_loop
 	jsr hex_digit_to_nybble
+	and #1
 	bra	store_ram_bank
 default_video_bank:
 	lda #0


### PR DESCRIPTION
As discussed in #134 we want to avoid stomping on user ZP.  There are enough scratch ZP locations that belong to BASIC that we can use while the monitor is running, so instead of preserving any ZP, we can simply take over those locations.

This PR also creates a new command `K` which changes the RAM bank, and can also be used to set VRAM/I2C modes. the old `O` command is now for changing only the ROM bank.

Other cleanup done as well.

Closes #111 