### PR TITLE
Set default device number

### DIFF
--- a/bannex/x16edit.s
+++ b/bannex/x16edit.s
@@ -1,7 +1,7 @@
 .include "banks.inc"
 
 .export x16edit
-.import bajsrfar, frmevl, valtyp, fcerr, frefac, index1
+.import bajsrfar, frmevl, valtyp, fcerr, frefac, index1, basic_fa
 
 .segment "ANNEX"
 
@@ -9,12 +9,12 @@
 	beq new ; No input param, open editor with a new empty buffer
 	jsr frmevl ; Evaluate input
 	bit valtyp
-	bmi file ; Input is a string, try to open file in the editor
+	bmi set_file ; Input is a string, try to open file in the editor
 
 error:
 	jmp fcerr ; Input was not a string => error
 
-file:
+set_file:
 	jsr frefac ; Get string
 	beq new ; String is empty, open new empty buffer
 	
@@ -23,20 +23,27 @@ file:
 	sta $02 ; R0L = file name address low
 	lda index1+1
 	sta $03 ; R0H = file name address high
+	bra launch
+
+new:
+	stz $04 ; R1L = file name length, 0 => no file
+
+launch:
 	ldx #10 ; First RAM bank used by the editor
 	ldy #255 ; Last RAM bank used by the editor
-	
+	stz $05 ; Default value: Auto-indent and word
+	stz $06 ; Default value: Tab stop width
+	stz $07 ; Default value: Word wrap position
+	lda basic_fa 
+	sta $08 ; Set current active device number
+	stz $09 ; Default value: text/background
+	stz $0a ; Default value: header
+	stz $0b ; Default value: status bar
+
 	jsr bajsrfar
-	.word $C003
+	.word $C006
 	.byte BANK_X16EDIT
 	rts
 
-new:
-	ldx #10 ; First RAM bank used by the editor
-	ldy #255 ; Last RAM bank used by the editor
-	stz $04 ; R1L = file name length, 0 => no file
-	jsr bajsrfar
-	.word $C003
-	.byte BANK_X16EDIT
-	rts
+
 .endproc


### PR DESCRIPTION
This makes EDIT use the default device number provided by basic_fa.

If you select a device that is not present, this is correctly reported by the editor if an SD card image is attached.

But if the host file system is used, no error is raised.