### PR TITLE
[BASIC] fix BASIC V2 bug not resetting variables pointer when chain-loading

### DIFF
--- a/basic/code26.s
+++ b/basic/code26.s
@@ -187,9 +187,11 @@ cld65	stx vartab
 ;
 ;program load
 ;
-cld70	jsr stxtpt
+cld70	stx vartab
+	sty vartab+1    ;end load address
+	jsr stxtpt
 	jsr lnkprg
-	jmp fload
+	jmp cleart
 
 copen	jsr paoc        ;parse statement
 	jsr $ffc0       ;open it


### PR DESCRIPTION
If one ran

`10 LOAD "OTHERPROG.PRG"`

and the new program was written in BASIC and used variables, the new program would be corrupted.  This resolves this issue by properly setting vartab based on the load-end, even when not in immediate mode.