### PR TITLE
[BASIC] LINPUT(#)/BINPUT# fix spurious STRING TOO LONG after string GC

### DIFF
--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -823,8 +823,10 @@ linput:
 	lda #buflen
 
 in2var:             ; input (line or block) to var
-	sta size        ; store max length
+	pha
 	jsr strspa      ; allocate string space
+	pla
+	sta size        ; store max length
 
 	ldy #0
 in2varc:


### PR DESCRIPTION
The `size` memory location was getting clobbered by string garbage collection if it happened to run inside of `strspa`.  This works around that problem.