### PR TITLE
[BASIC] switch bank to BLOAD end

### DIFF
--- a/basic/code26.s
+++ b/basic/code26.s
@@ -172,6 +172,8 @@ cld55	jmp error
 ;
 cld60	stx sxreg   ; save [B]LOAD addr so BASIC can inspect
 	sty syreg
+	lda ram_bank
+	sta crambank
 	lda eormsk
 	bne cld20
 	lda txtptr+1


### PR DESCRIPTION
In previous versions, you could PEEK(0) immediately after a BLOAD, but it didn't reset the bank set by the `BANK` command.  This lack of durability was problematic.  Now the end bank after a LOAD/BLOAD is set as if it were via the BANK command.  It's still able to be PEEKed from memory location 0, but this value will now persist even if there are other statements in between the BLOAD and PEEK.