### PR TITLE
[KERNAL] joystick: restore older latch/clock release order

### DIFF
--- a/kernal/drivers/x16/joystick.s
+++ b/kernal/drivers/x16/joystick.s
@@ -67,8 +67,7 @@ joystick_scan:
 	pla
 	pha
 	pla
-	lda #bit_jclk
-	sta nes_data
+	stz nes_data
 
 	; read 3x 8 bits
 	ldx #bit_jclk


### PR DESCRIPTION
The previous `trb` reset both latch and clock.  The changes afterwards caused only clock to be reset and then a few instructions later, latch got reset.  This restores the old behavior, simulating the `trb`, and joysticks in emu now work correctly.

Both R45 and this commit work on my hardware.