### PR TITLE
Make joy latch as long as it was in R44

### DIFF
--- a/kernal/drivers/x16/joystick.s
+++ b/kernal/drivers/x16/joystick.s
@@ -67,6 +67,8 @@ joystick_scan:
 	pla
 	pha
 	pla
+	pha
+	pla
 	stz nes_data
 
 	; read 3x 8 bits


### PR DESCRIPTION
R44 seems to have had better support for different types of controllers according to testimonies on Discord.

In R44 the latch period was 4.25 us, if I'm counting the cycles correctly:

```
        tsb nes_data ; 0, I here assume that the latch is set when the instruction is finished
	pha ; 3
	pla ; 4
	pha ; 3
	pla ; 4
	pha ; 3
	pla ; 4
	pha ; 3
	pla ; 4
	trb nes_data ; 6 => total 34 cycles = 4.25 us
```

In the current master this is a bit shorter, I think 4.00 us:

```
	sta nes_data ; 0
	pha ; 3
	pla ; 4
	pha ; 3
	pla ; 4
	pha ; 3
	pla ; 4
	pha ; 3
	pla ; 4
	stz nes_data ; 4 => total 32 cycles = 4.00 us
```

This PR adds another pha+pla, making the latch period 39 cycles=4.87 us.
