### PR TITLE
Prevent mouse_scan during mouse_get

### DIFF
--- a/kernal/drivers/x16/ps2mouse.s
+++ b/kernal/drivers/x16/ps2mouse.s
@@ -197,7 +197,6 @@ mouse_scan:
 	rts
 
 _mouse_scan:
-	sta mouse_mutex
 	bit msepar ; do nothing if mouse is off
 	bpl @a
 	

--- a/kernal/drivers/x16/ps2mouse.s
+++ b/kernal/drivers/x16/ps2mouse.s
@@ -34,8 +34,6 @@ wheel:	.res 1           ;    Intellimouse wheel buffer
 idat:	.res 1           ;    Intellimouse data packet
 device_id:
 	.res 1           ;    mouse device ID
-mouse_mutex:
-	.res 1	
 
 I2C_ADDRESS = $42
 I2C_GET_MOUSE_MOVEMENT_OFFSET = $21
@@ -57,9 +55,6 @@ mouse_config:
 	KVARS_END
 	rts
 _mouse_config:
-	; mouse mutex off
-	stz mouse_mutex
-
 	pha
 	phx
 	phy
@@ -186,14 +181,8 @@ mous3:	lda msepar
 
 mouse_scan:
 	KVARS_START
-
-	; check mouse mutex
-	lda mouse_mutex
-	bne :+
-	
 	jsr _mouse_scan
-
-:	KVARS_END
+	KVARS_END
 	rts
 
 _mouse_scan:
@@ -349,15 +338,10 @@ mouse_update_position:
 
 mouse_get:
 	KVARS_START
-	; mouse mutex on
-	lda #1
-	sta mouse_mutex
-
+	php
+	sei
 	jsr _mouse_get
-	
-	; mouse mutex off
-	stz mouse_mutex
-
+	plp
 	KVARS_END
 	rts
 

--- a/kernal/drivers/x16/ps2mouse.s
+++ b/kernal/drivers/x16/ps2mouse.s
@@ -187,7 +187,7 @@ mous3:	lda msepar
 mouse_scan:
 	KVARS_START
 
-	; check mouse mutes
+	; check mouse mutex
 	lda mouse_mutex
 	bne :+
 	
@@ -354,10 +354,11 @@ mouse_get:
 	sta mouse_mutex
 
 	jsr _mouse_get
-	KVARS_END
-
+	
 	; mouse mutex off
 	stz mouse_mutex
+
+	KVARS_END
 	rts
 
 _mouse_get:


### PR DESCRIPTION
Guard mouse_get with SEI to prevent mouse data being changed by mouse_scan.