### PR TITLE
Fix overflow in FB_get/set_pixels when lsb of amount is 0

### DIFF
--- a/graphics/drivers/framebuffer.s
+++ b/graphics/drivers/framebuffer.s
@@ -213,6 +213,9 @@ set_pixels_FG:
 	inc r0H
 	dec r1H
 	bne @c
+	lda r1L
+	bne @a
+	rts
 
 @a:	ldx r1L
 @b:	ldy #0
@@ -248,6 +251,9 @@ get_pixels_FG:
 	inc r0H
 	dec r1H
 	bne @c
+	lda r1L
+	bne @a
+	rts
 
 @a:	ldx r1L
 @b:	ldy #0


### PR DESCRIPTION
Loops didn't verify if there was actually any remaining data left to copy. Hence copying 256 bytes more than asked for.  Fixes #217 