### PR TITLE
Correctly set default drivenr from petscii chr too. Fixes #216

### DIFF
--- a/bannex/dos.s
+++ b/bannex/dos.s
@@ -4,6 +4,7 @@
 readst = $ffb7
 
 .feature labels_without_colons
+.macpack longbranch
 
 .importzp index1, txtptr, eormsk, poker
 
@@ -221,9 +222,7 @@ dos2:
 	lda (index1),y
 ; dir?
 	cmp #'$'
-	bne :+
-	jmp disk_dir
-:	
+	jeq disk_dir
 ; switch default drive?
 	cmp #'8'
 	beq dosswchr

--- a/bannex/dos.s
+++ b/bannex/dos.s
@@ -221,12 +221,14 @@ dos2:
 	lda (index1),y
 ; dir?
 	cmp #'$'
-	beq disk_dir
+	bne :+
+	jmp disk_dir
+:	
 ; switch default drive?
 	cmp #'8'
-	beq dossw
+	beq dosswchr
 	cmp #'9'
-	beq dossw
+	beq dosswchr
 
 ;***************
 ; DOS command
@@ -301,6 +303,8 @@ dos0	plp
 
 ;***************
 ; switch default drive
+dosswchr:
+	and #15
 dossw	sta basic_fa
 	rts
 


### PR DESCRIPTION
had to turn the first beq into a jmp because the offset became too large and ca65 doesn't do this automatically :|