### PR TITLE
Add small delay before sampling controller data to fix #215

### DIFF
--- a/kernal/drivers/x16/joystick.s
+++ b/kernal/drivers/x16/joystick.s
@@ -75,7 +75,7 @@ joystick_scan:
 	ldx #bit_jclk
 	ldy #8
 l1:	stz nes_data ; Drive NES clock low (NES controller doesn't change when low)
-
+	nop          ; Delay for slow SNES controllers
 	lda nes_data ; Read all controller bits
 	stx nes_data ; Drive NES clock high
 


### PR DESCRIPTION
Give slower controllers a few extra nanoseconds to respond to NES clock changes.