### PR TITLE
implement VAL_1 routine $fe09 of the FP library

### DIFF
--- a/basic/code17.s
+++ b/basic/code17.s
@@ -5,9 +5,9 @@ conint	jsr posint
 	ldx faclo
 	jmp chrgot
 val	jsr len1
-	bne *+5
+val_str	bne @1
 	jmp zerofc
-	ldx txtptr
+@1:	ldx txtptr
 	ldy txtptr+1
 	stx strng2
 	sty strng2+1
@@ -265,3 +265,6 @@ mlex10
 mlexmi
 	sta tenexp	;save result.
 	jmp finec
+
+
+.export val_str

--- a/math/code25.s
+++ b/math/code25.s
@@ -144,6 +144,15 @@ getadr	lda facsgn
 	ldy facmo+1
 	rts             ;it's all done.
 
+val_1	stx index
+	sty index+1
+	cmp #0
+	jmp val_str	; continue in Basic
+
+
+.import val_str
+
+
 ;**************************
 ; generalized versions of
 ; what BASIC calls

--- a/math/jumptab.s
+++ b/math/jumptab.s
@@ -59,11 +59,8 @@
 	; Convert FAC to ASCIIZ string at fbuffr
 	jmp fout   ; $BDDD
 
-	; XXX VAL_1, a frontend to fin ($BCF3) is missing
-	; XXX because of the dependency on CHRGET.
-	; XXX We should add it after removing the
-	; XXX depencency.
-	.byte 0,0,0
+	; Convert string in .X:.Y length in .A to floating point number in FAC
+	jmp val_1
 
 	; .A:.Y = (u16)FAC
 	; [*** C128 difference: does not store the

--- a/math/math.inc
+++ b/math/math.inc
@@ -23,7 +23,7 @@
 ayint	= $fe00 ; facmo+1:facmo = (s16)FAC
 givayf	= $fe03 ; FAC = (s16).A:.Y
 fout	= $fe06 ; Convert FAC to ASCIIZ string at fbuffr
-val_1	= $fe09 ;
+val_1	= $fe09 ; Convert string in .X:.Y length in .A to floating point number in FAC
 getadr	= $fe0c ; .A:.Y = (u16)FAC
 floatc	= $fe0f ; C128 API, use floats instead
 ; Math Functions


### PR DESCRIPTION
It calls into the equivalent code that was already present in Basic in the val routine.

I am not familiar with ca65's import/export mechanism of symbols, so please have an extra look at that

[testprog.zip](https://github.com/X16Community/x16-rom/files/13494350/testprog.zip)

source code for the above test program:

```
%import textio
%import floats
%import string
%zeropage basicsafe
%option no_sysinit

main {
    sub start() {
        str buffer = "???????????????????????????"
        repeat {
            txt.print("enter number: ")
            void txt.input_chars(buffer)
            txt.print("\nprog8's parse_f: ")
            float value = floats.parse_f(buffer)
            floats.print_f(value)
            
            ; floats.VAL_1 is defined as:
            ; romsub $fe09 = VAL_1(uword string @XY, ubyte length @A) clobbers(A,X,Y) -> float @FAC1
            txt.print("\nrom val_1: ")
            value = floats.VAL_1(buffer, string.length(buffer))
            floats.print_f(value)
            txt.nl()
        }
    }
}
```

The [how-to use FP](https://github.com/X16Community/x16-docs/blob/master/X16%20Reference%20-%2005%20-%20Math%20Library.md#how-to-use-the-routines) should help understand what's happening