### PR TITLE
Add pausing, paging and line-stepping to the LIST command

### DIFF
--- a/basic/code3.s
+++ b/basic/code3.s
@@ -60,7 +60,8 @@ ploop1	iny
 	sta lowtr+1
 	bne list4
 grody	jmp ready
-qplop	jmp (iqplop)
+qplop	jsr listp
+	jmp (iqplop)
 nqplop	bpl ploop
 	cmp #pi
 	beq ploop

--- a/basic/code3.s
+++ b/basic/code3.s
@@ -61,7 +61,7 @@ ploop1	iny
 	bne list4
 grody	jmp ready
 qplop	jmp (iqplop)
-nqplop	jsr listp
+nqplop	jsr listp	; Routine to handle LIST pausing, paging & line stepping
 	bpl ploop
 	cmp #pi
 	beq ploop

--- a/basic/code3.s
+++ b/basic/code3.s
@@ -60,9 +60,9 @@ ploop1	iny
 	sta lowtr+1
 	bne list4
 grody	jmp ready
-qplop	jsr listp
-	jmp (iqplop)
-nqplop	bpl ploop
+qplop	jmp (iqplop)
+nqplop	jsr listp
+	bpl ploop
 	cmp #pi
 	beq ploop
 	bit dores

--- a/basic/code3.s
+++ b/basic/code3.s
@@ -36,7 +36,8 @@ list4	ldy #1
 	cpx linnum
 	beq typlin
 tstdun	bcs grody
-typlin	sty lstpnt
+typlin	jsr listp	; Routine to handle LIST pausing, paging & line-stepping
+	sty lstpnt
 	jsr linprt
 	lda #' '
 prit4	ldy lstpnt
@@ -61,8 +62,7 @@ ploop1	iny
 	bne list4
 grody	jmp ready
 qplop	jmp (iqplop)
-nqplop	jsr listp	; Routine to handle LIST pausing, paging & line stepping
-	bpl ploop
+nqplop	bpl ploop
 	cmp #pi
 	beq ploop
 	bit dores

--- a/basic/declare.s
+++ b/basic/declare.s
@@ -184,3 +184,6 @@ usrpok	.res 3           ;$0310 user function dispatch
     exec_flag: .res 1
     exec_addr: .res 2
     exec_bank: .res 1
+
+    lp_dopause: .res 1
+    lp_screenpause: .res 1

--- a/basic/token2.s
+++ b/basic/token2.s
@@ -134,8 +134,8 @@ reslst3
 	.byt "M", 'Y' + $80
 	.byt "M", 'B' + $80
 	.byt "JO", 'Y' + $80
-	.byt "HEX", $a4
-	.byt "BIN", $a4
+	.byt "HEX", '$' + $80
+	.byt "BIN", '$' + $80
 	.byt "I2CPEE", 'K' + $80
 	.byt "POINTE", 'R' + $80
 	.byt "STRPT", 'R' + $80

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -964,18 +964,18 @@ cedit:
 ; Arrow down will show one line at a time
 ;
 ;******************************************************************
-nlines	= $0387
-curs_y	= $0383
+nlines	= $0387			; These variables are in KERNAL space
+curs_y	= $0383			; Could not figure out how to import
 listp:
 	php			; Save cpu flags as they are used after this function
 	pha			; BASIC uses the a,y registers, they will be restored
 	phy			; before returning from this function
 	stz	ram_bank	; Set RAM bank 0 for variables
 
-	lda	$200
+	lda	$200		; Use keyboard buffer to see if first run
 	beq	@notfirst
 	stz	$200
-	stz	lp_dopause
+	stz	lp_dopause	; Initialize variables
 	stz	lp_screenpause
 @notfirst:
 	jsr	$FFE4		; GETIN
@@ -1028,7 +1028,11 @@ listp:
 	jsr	$FFD2		; CHROUT
 @pauseloop:
 	jsr	$FFE4		; GETIN
-	cmp	#$20		; Is Space ?
+	cmp	#$03		; Is STOP ?
+	bne	:+
+	jsr	$FEC3
+	bra	@end
+:	cmp	#$20		; Is Space ?
 	bne	@pgdown
 	stz	lp_dopause
 	stz	lp_screenpause


### PR DESCRIPTION
On the community website, koyaa has written a wedge that enables the LIST command to pause and then do page- or line-stepping. https://cx16forum.com/forum/viewtopic.php?p=30587
His code has been modified into this pull request.

LIST will continue to work as always, but if space is pressed during a listing, the listing will be paused.
While paused, it is possible to use pagedown to show one page at a time or use arrow down to show one line at a time.
If space is pressed in the paused state, the listing is "unpaused" and continues to function as normal.

Note: The code is unable to know the length of a BASIC line ahead of time which means page-stepping will have to stop early enough to ensure that the screen does not scroll. That shows it self as several "unused" lines at the bottom of the screen. For single-line stepping, this is not an issue.