### PR TITLE
Prevent OLD command from hanging when run without a program in memory

### DIFF
--- a/basic/code1.s
+++ b/basic/code1.s
@@ -200,7 +200,13 @@ chead	ldy #1
 	beq lnkrts
 	ldy #4
 czloop	iny
-	lda (index),y
+	bne :+		; Continue as normal as long as Y has not rolled over to 0
+	tya		; If Y has rolled over to 0
+	sta (index),y	; store 0's in the two first bytes of the txttab buffer
+	iny		; to show that there is no BASIC program
+	sta (index),y
+	bra lnkrts	; exit function (better with just an RTS?)
+:	lda (index),y
 	bne czloop
 	iny
 	tya

--- a/basic/code1.s
+++ b/basic/code1.s
@@ -201,11 +201,11 @@ chead	ldy #1
 	ldy #4
 czloop	iny
 	bne :+		; Continue as normal as long as Y has not rolled over to 0
-	tya		; If Y has rolled over to 0
-	sta (index),y	; store 0's in the two first bytes of the txttab buffer
-	iny		; to show that there is no BASIC program
+	tya		; If Y has rolled over to 0, we have encountered a line > 255 bytes.
+	sta (index),y	; store 0's in the next two bytes
+	iny		; to indicate the end of the BASIC program
 	sta (index),y
-	bra lnkrts	; exit function (better with just an RTS?)
+	rts
 :	lda (index),y
 	bne czloop
 	iny

--- a/basic/init.s
+++ b/basic/init.s
@@ -124,10 +124,6 @@ usedef	stx memsiz
 	ldy #0
 	tya
 	sta (txttab),y
-;	ldy #6		;prevent OLD command from hanging when run without a
-;	sta (txttab),y	;program in memory. When ($0801),6 and ($0801),8 are 0
-;	ldy #8		;OLD will restore random data, but will not hang
-;	sta (txttab),y
 	inc txttab
 	bne init20
 	inc txttab+1

--- a/basic/init.s
+++ b/basic/init.s
@@ -124,10 +124,10 @@ usedef	stx memsiz
 	ldy #0
 	tya
 	sta (txttab),y
-	ldy #6		;prevent OLD command from hanging when run without a
-	sta (txttab),y	;program in memory. When ($0801),6 and ($0801),8 are 0
-	ldy #8		;OLD will restore random data, but will not hang
-	sta (txttab),y
+;	ldy #6		;prevent OLD command from hanging when run without a
+;	sta (txttab),y	;program in memory. When ($0801),6 and ($0801),8 are 0
+;	ldy #8		;OLD will restore random data, but will not hang
+;	sta (txttab),y
 	inc txttab
 	bne init20
 	inc txttab+1

--- a/basic/init.s
+++ b/basic/init.s
@@ -124,6 +124,10 @@ usedef	stx memsiz
 	ldy #0
 	tya
 	sta (txttab),y
+	ldy #6		;prevent OLD command from hanging when run without a
+	sta (txttab),y	;program in memory. When ($0801),6 and ($0801),8 are 0
+	ldy #8		;OLD will restore random data, but will not hang
+	sta (txttab),y
 	inc txttab
 	bne init20
 	inc txttab+1


### PR DESCRIPTION
If OLD is run on a newly booted system, it will just hang.
This change allows OLD to run without hanging, it restores a random BASIC line, but it does not hang