### PR TITLE
Monitor returns to caller at exit if not having to return to BASIC.

### DIFF
--- a/kernal/cbm/nmi.s
+++ b/kernal/cbm/nmi.s
@@ -7,7 +7,6 @@
 .feature labels_without_colons
 
 rom_bank = 1
-monitor = $fecc
 clrch   = $ffcc
 .import enter_basic, cint, ioinit, restor, nminv
 .import call_audio_init

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -352,4 +352,5 @@ monitor:
 	jsr jsrfar
 	.word $c000
 	.byte BANK_MONITOR
+	rts
 	;not reached

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -353,4 +353,4 @@ monitor:
 	.word $c000
 	.byte BANK_MONITOR
 	rts
-	;not reached
+


### PR DESCRIPTION
Previously calling the `monitor()` kernal routine was a one way trip and exiting the monitor always returned you to a BASIC prompt.

Now it only does a basic warm start if the monitor was called from BASIC (or the BRK vector, apparently), and if not, it simply does an RTS to hand control flow back to the caller.