### PR TITLE
Prevent file overwrite from deleting directories

### DIFF
--- a/fat32/fat32.s
+++ b/fat32/fat32.s
@@ -2702,14 +2702,22 @@ fat32_create:
 	stz fat32_errno
 
 	; Check if context is free
-	lda cur_context + context::flags
+	lda cur_context + context::flags 
 	beq @1
 	plp ; overwrite flag
 @error:	clc
 	rts
 @1:
-	; Check if directory entry already exists?
-	lda #0 ; allow files and directories
+	; Check if a directory exists with the same name
+	lda #$40 ; allow directories only
+	jsr find_dirent
+	bcc @2
+	plp
+	lda #ERRNO_FILE_EXISTS
+	jmp set_errno
+
+	; Check if file already exists?
+@2:	lda #$80 ; allow files only
 	jsr find_dirent
 	bcs @exists
 	plp ; overwrite flag

--- a/fat32/fat32.s
+++ b/fat32/fat32.s
@@ -2702,7 +2702,7 @@ fat32_create:
 	stz fat32_errno
 
 	; Check if context is free
-	lda cur_context + context::flags 
+	lda cur_context + context::flags
 	beq @1
 	plp ; overwrite flag
 @error:	clc


### PR DESCRIPTION
If you save a file prepending the file name with "@:" it will currently delete a directory having the same name.

I suppose this is bad, and that it will orphan all files in that directory.

The attached code prevents overwriting directories this way.

I'm not sure about the error number. There're not a lot of suitable error codes to choose from in dos/file.s. For now it returns FILE EXISTS when you try to overwrite a directory.

This is somewhat linked to issue #232.