### PR TITLE
Inline `irq_ack`

### DIFF
--- a/kernal/cbm/irq.s
+++ b/kernal/cbm/irq.s
@@ -15,13 +15,11 @@
 .import mouse_scan
 .import joystick_scan
 .import cursor_blink
-.import irq_ack
 .import led_update
 .export panic
 
 .include "banks.inc"
-
-rom_bank = 1
+.include "io.inc"
 
 ; VBLANK IRQ handler
 ;
@@ -33,7 +31,9 @@ key
 	jsr kbd_scan
 	jsr led_update
 
-	jsr irq_ack
+	lda #1
+	sta VERA_ISR    ;ack VERA VBLANK
+
 .ifp02
 	pla
 	tay

--- a/kernal/drivers/x16/x16.s
+++ b/kernal/drivers/x16/x16.s
@@ -11,7 +11,6 @@
 
 .export ioinit
 .export iokeys
-.export irq_ack
 .export emulator_get_data
 .export vera_wait_ready
 .export call_audio_init
@@ -48,15 +47,6 @@ ioinit:
 iokeys:
 	lda #1
 	sta VERA_IEN    ;VERA VBLANK IRQ for 60 Hz
-	rts
-
-;---------------------------------------------------------------
-; ACK VBLANK IRQ
-;
-;---------------------------------------------------------------
-irq_ack:
-	lda #1
-	sta VERA_ISR    ;ACK VERA VBLANK
 	rts
 
 ;---------------------------------------------------------------

--- a/kernal/open-roms/interrupts/ea7e.ack_cia1_return_from_interrupt.s
+++ b/kernal/open-roms/interrupts/ea7e.ack_cia1_return_from_interrupt.s
@@ -9,7 +9,8 @@
 
 clear_cia1_interrupt_flag_and_return_from_interrupt:
 
-	jsr irq_ack
+	lda #1
+	sta VERA_ISR
 
 	; FALL THROUGH to $EA81
 

--- a/kernal/open-roms/open-roms.s
+++ b/kernal/open-roms/open-roms.s
@@ -249,7 +249,6 @@ start = hw_entry_reset
 .import screen_set_char, screen_set_color, screen_set_position, screen_get_char, screen_get_color, screen_copy_line, screen_clear_line, screen_init, screen_mode, screen_set_charset
 .import enter_basic
 .import kbd_config
-.import irq_ack
 .import emulator_get_data
 
 ;


### PR DESCRIPTION
`irq_ack` is only called in `keys` and consists of a `lda` and a `sta` instruction, which take five cycles; by inlining the code, code execution time is reduced by 12 cycles (`jsr` + `rts`).

I've also replaced the call in open-roms; I don't know whether that's all that is necessary for open-roms, however, it doesn't even compile prior to my changes, so I cannot verify it.