### PR TITLE
[KERNAL/FAT32/CODEX] Remove support for non-65C02 CPUs and the C64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,6 @@ ASFLAGS     += -D CPU_65C02=1
 ASFLAGS     +=  $(VERSION_DEFINE)
 # put all symbols into .sym files
 ASFLAGS     += -g
-
-ASFLAGS     += -D MACHINE_X16=1
 # all files are allowed to use 65SC02 features
 ASFLAGS     += --cpu 65SC02
 

--- a/codex/Makefile
+++ b/codex/Makefile
@@ -132,7 +132,7 @@ KSUP_VECS = \
 	   $(OBJDIR)/cx_vecs.o \
 		$(OBJDIR)/kernsup_cx.o
 
-KSUP_DEFS = -D CPU_65C02=1  -g -D MACHINE_X16=1 --cpu 65SC02
+KSUP_DEFS = -D CPU_65C02=1  -g --cpu 65SC02
 
 UT_INCS=$(TESTDIR)/assert.s
 

--- a/fat32/fat32.s
+++ b/fat32/fat32.s
@@ -3102,7 +3102,6 @@ fat32_read_again:
 	; Copy bytecnt bytes from buffer
 	ldy bytecnt
 
-.ifdef MACHINE_X16
 .importzp krn_ptr1
 	bit krn_ptr1        ; MSB=1: stream copy, MSB=0: normal copy
 	bpl @5a
@@ -3117,8 +3116,6 @@ fat32_read_again:
 	bcs @5b             ; destination above banked RAM
 	jmp x16_banked_copy
 @5b:
-.endif
-
 	dey
 	beq @6b
 @6:	lda (fat32_bufptr), y
@@ -3150,7 +3147,6 @@ fat32_read_done:
 	rts
 
 
-.ifdef MACHINE_X16
 ;-----------------------------------------------------------------------------
 ; restores ram_bank prior to each write, and wraps the
 ; pointer if the write address crosses the $c000 threshold
@@ -3219,7 +3215,6 @@ x16_stream_copy:
 	lda (fat32_bufptr),y
 	sta (fat32_ptr)
 	jmp fat32_read_cont2
-.endif
 
 
 ;-----------------------------------------------------------------------------

--- a/inc/banks.inc
+++ b/inc/banks.inc
@@ -17,7 +17,6 @@ BANK_BASLOAD = $0F
 
 ; XXX these constant RAM addresses are KERNAL
 ; XXX implementation details and need to go away!
-.ifdef MACHINE_X16
 cbdos_flags= $0268
 status     = $0287 ; channel: status byte
 jsrfar3    = $02c4 ; jsrfar: RAM part
@@ -26,11 +25,6 @@ imparm     = $82   ; jsrfar: temporary byte
 stavec     = $03b2 ; stash: argument
 irq        = $038b ; irq handler: RAM part         this value MUST NEVER CHANGE starting from R42
 nmi        = $03b7 ; nmi handler: RAM trampoline   this value MUST NEVER CHANGE starting from R42
-.elseif .defined(MACHINE_C64)
-status     = $029F
-;fa         = $029F
-imparm     = $E2
-.endif
 
 ; editor keystroke vectors (currently used by MONITOR)
 edkeyvec   = $ac03
@@ -40,8 +34,6 @@ edkeybk    = $ac05
 ; 0:   KVARS
 ; 1-9: GEOS BG SCREEN (320x200) [not currently enabled]
 ; 255: CBDOS
-
-.ifdef MACHINE_X16
 
 .macro KVARS_START
 .import kvswitch_tmp1, kvswitch_tmp2
@@ -114,13 +106,3 @@ edkeybk    = $ac05
 	sta ram_bank
 	lda kvswitch_tmp1
 .endmacro
-
-.else ; C64
-
-.macro KVARS_START
-.endmacro
-
-.macro KVARS_END
-.endmacro
-
-.endif

--- a/inc/mac.inc
+++ b/inc/mac.inc
@@ -182,12 +182,7 @@
 
 .macro smbf bitN, dest
 	lda #1 << bitN
-	.ifp02
-		ora dest
-		sta dest
-	.else
-		tsb dest
-	.endif
+	tsb dest
 .endmacro
 
 .macro rmb bitN, dest
@@ -197,14 +192,8 @@
 .endmacro
 
 .macro rmbf bitN, dest
-	.ifp02
-		lda #(1 << bitN) ^ $ff
-		and dest
-		sta dest
-	.else
-		lda #1 << bitN
-		trb dest
-	.endif
+	lda #1 << bitN
+	trb dest
 .endmacro
 
 .macro bbs bitN, source, addr
@@ -288,12 +277,6 @@
 	txa
 	beq addr
 .endmacro
-
-.ifp02
-	.macro bra addr
-		jmp addr
-	.endmacro
-.endif
 
 .macro IncW addr
 	.local @j

--- a/kernal/cbm/channel/load.s
+++ b/kernal/cbm/channel/load.s
@@ -121,7 +121,7 @@ bld10
 bld11:
 	ldx eal
 	ldy eah
-    phy             ;save address hi
+	phy             ;save address hi
 bld12:
 	lda #0          ;load as many bytes as device wants
 	jsr macptr

--- a/kernal/cbm/channel/load.s
+++ b/kernal/cbm/channel/load.s
@@ -121,16 +121,12 @@ bld10
 bld11:
 	ldx eal
 	ldy eah
-.ifdef MACHINE_X16
-        phy             ;save address hi
-.endif
+    phy             ;save address hi
 bld12:
 	lda #0          ;load as many bytes as device wants
 	jsr macptr
 	bcc :+
-.ifdef MACHINE_X16
 	pla             ;clear hi address from stack
-.endif
 	jmp ld40        ;not supported, fall back to byte-wise
 :	txa
 	clc
@@ -138,7 +134,6 @@ bld12:
 	sta eal
 	tya
 	adc eah
-.ifdef MACHINE_X16
 	; fix-up address when loading into banked RAM:
 	; this should reflect the banked RAM address following
 	; the last byte written (exception: $BFFF -> $A000)
@@ -154,7 +149,6 @@ bld12:
 	sbc #$20
 	bra @loop
 @skip
-.endif
 	sta eah
 	bit status      ;eoi?
 	bvc bld10       ;no...continue load
@@ -218,7 +212,6 @@ ld50	ldy #0
 ld60	inc eal         ;increment store addr
 	bne ld64
 	inc eah
-.ifdef MACHINE_X16
 ;
 ;if necessary, wrap to next bank
 ;
@@ -231,7 +224,6 @@ ld60	inc eal         ;increment store addr
 ld62	lda #$a0        ;wrap to bottom of high ram
 	sta eah
 	inc ram_bank    ;move to next ram bank
-.endif
 ld64	bit status      ;eoi?
 	bvc ld40        ;no...continue load
 ;
@@ -296,7 +288,6 @@ ld410	jsr spmsg
 	beq frmto1      ;skip if verify
 	ldy #ms7-ms1    ;"from $"
 msghex	jsr msg
-.ifdef MACHINE_X16
 	lda eah
 	cmp #$a0
 	bcc :+
@@ -307,7 +298,6 @@ msghex	jsr msg
 	lda #':'
 	jsr bsout
 :
-.endif
 	lda eah
 	jsr hex8
 	lda eal

--- a/kernal/cbm/irq.s
+++ b/kernal/cbm/irq.s
@@ -34,15 +34,8 @@ key
 	lda #1
 	sta VERA_ISR    ;ack VERA VBLANK
 
-.ifp02
-	pla
-	tay
-	pla
-	tax
-.else
 	ply
 	plx
-.endif
 	pla
 	rti             ;exit from irq routines
 

--- a/kernal/drivers/generic/softclock_date.s
+++ b/kernal/drivers/generic/softclock_date.s
@@ -9,12 +9,6 @@
 .include "io.inc"
 .include "regs.inc"
 
-.ifp02
-.macro bra addr
-	jmp addr
-.endmacro
-.endif
-
 .segment "KVARSB0"
 
 datey:	.res 1           ;    year-1900

--- a/kernal/drivers/generic/softclock_time.s
+++ b/kernal/drivers/generic/softclock_time.s
@@ -9,13 +9,6 @@
 .include "io.inc"
 .include "regs.inc"
 
-.ifp02
-.macro stz addr
-	lda #0
-	sta addr
-.endmacro
-.endif
-
 .segment "KVARSB0"
 
 timeh:	.res 1           ;    hours

--- a/kernal/vectors.s
+++ b/kernal/vectors.s
@@ -77,9 +77,6 @@
 	;
 	; framebuffer API
 	;
-.ifdef MACHINE_C64
-	.res 14*3
-.else
 	jmp FB_init                    ; $FEF6: FB_init
 	jmp FB_get_info                ; $FEF9: FB_get_info
 	jmp FB_set_palette             ; $FEFC: FB_set_palette
@@ -94,7 +91,6 @@
 	jmp FB_fill_pixels             ; $FF17: FB_fill_pixels
 	jmp FB_filter_pixels           ; $FF1A: FB_filter_pixels
 	jmp FB_move_pixels             ; $FF1D: FB_move_pixels
-.endif
 
 	;
 	; graph high-level API


### PR DESCRIPTION
The ROM isn't going to be used with a C64 anymore, and the ROM neither assembles nor works on a stock 6502 or 6510 anymore. This PR removes the leftover machinery.