### PR TITLE
[KERNAL] fix two DOW bugs

### DIFF
--- a/kernal/drivers/x16/rtc.s
+++ b/kernal/drivers/x16/rtc.s
@@ -126,7 +126,7 @@ rtc_set_date_time:
 	lda r3H
 	and #$07
 	ora #$08                  ; enable battery backup
-	jsr i2c_write_byte_as_bcd ; 3: day of week
+	jsr i2c_write_byte        ; 3: day of week
 
 	dey
 	lda r1H

--- a/kernal/ieee_switch.s
+++ b/kernal/ieee_switch.s
@@ -190,7 +190,7 @@ upload_time:
 @1:	lda 0,x
 	pha
 	inx
-	cpx #9
+	cpx #10
 	bne @1
 
 	jsr clock_get_date_time
@@ -209,7 +209,7 @@ upload_time:
 	.word $c000 + 3 * 16
 	.byte BANK_CBDOS
 
-	ldx #8
+	ldx #9
 @4:	pla
 	sta 0,x
 	dex


### PR DESCRIPTION
Opening a file would clobber r3H, and setting the DOW programmatically could have cleared the VBATEN bit

Closes #249 