### PR TITLE
[KERNAL] init VARFONTS in ramtas

### DIFF
--- a/cfg/kernal-x16.cfgtpl
+++ b/cfg/kernal-x16.cfgtpl
@@ -21,7 +21,7 @@ SEGMENTS {
 	KVECTORS:   load = KVECTORS, type = bss;
 	KEYMAP:     load = KEYMAP,   type = bss;
 	KVARSB0:    load = KVARSB0,  type = bss, define=yes;
-	VARFONTS:   load = KVARSB0,  type = bss;
+	VARFONTS:   load = KVARSB0,  type = bss, define=yes;
 	USERPARM:   load = USERPARM, type = bss;
 
 	SIGNATURE:load = SIGNATURE,   type = ro;

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -86,7 +86,7 @@ ramtas:
 ;
 ; clear bank 0 VARFONTS
 ;
-.assert __VARFONTS_SIZE__ < 256, error, "KVARSB0 overflow!"
+.assert __VARFONTS_SIZE__ < 256, error, "VARFONTS overflow!"
 	ldx #<__VARFONTS_SIZE__
 :	stz __VARFONTS_LOAD__,x
 	dex

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -9,6 +9,7 @@
 .import __KERNRAM_LOAD__, __KERNRAM_RUN__, __KERNRAM_SIZE__
 .import __KERNRAM2_LOAD__, __KERNRAM2_RUN__, __KERNRAM2_SIZE__
 .import __KVARSB0_LOAD__, __KVARSB0_RUN__, __KVARSB0_SIZE__
+.import __VARFONTS_LOAD__, __VARFONTS_RUN__, __VARFONTS_SIZE__
 .import __VECB0_LOAD__, __VECB0_RUN__, __VECB0_SIZE__
 .import memtop
 .import membot
@@ -79,6 +80,15 @@ ramtas:
 .assert __KVARSB0_SIZE__ < 256, error, "KVARSB0 overflow!"
 	ldx #<__KVARSB0_SIZE__
 :	stz __KVARSB0_LOAD__,x
+	dex
+	bne :-
+
+;
+; clear bank 0 VARFONTS
+;
+.assert __VARFONTS_SIZE__ < 256, error, "KVARSB0 overflow!"
+	ldx #<__VARFONTS_SIZE__
+:	stz __VARFONTS_LOAD__,x
 	dex
 	bne :-
 


### PR DESCRIPTION
The prior location of VARFONTS was covered by the $200-$3FF clearing, so we need to also clear it in B0.