### PR TITLE
[KERNAL] implement native-capable jsrfar

### DIFF
--- a/cfg/audio-x16.cfgtpl
+++ b/cfg/audio-x16.cfgtpl
@@ -1,8 +1,8 @@
 MEMORY {
 	#include "x16.cfginc"
 
-	ROM:         start = $C000, size = $3B00, fill=yes, fillval=$AA;
-	KSUP_CODE10: start = $FB00, size = $03A8, fill=yes, fillval=$AA;
+	ROM:         start = $C000, size = $3A80, fill=yes, fillval=$AA;
+	KSUP_CODE10: start = $FA80, size = $0428, fill=yes, fillval=$AA;
 	KSUP_VEC10:  start = $FEA8, size = $0158, fill=yes, fillval=$AA;
 
 }

--- a/cfg/bannex-x16.cfgtpl
+++ b/cfg/bannex-x16.cfgtpl
@@ -1,8 +1,8 @@
 MEMORY {
 	#include "x16.cfginc"
 
-	ANNEX:     start = $C000, size = $3B00, fill=yes, fillval=$AA;
-	KSUP_CODE12: start = $FB00, size = $03A8, fill=yes, fillval=$AA;
+	ANNEX:     start = $C000, size = $3A80, fill=yes, fillval=$AA;
+	KSUP_CODE12: start = $FA80, size = $0428, fill=yes, fillval=$AA;
 	KSUP_VEC12:  start = $FEA8, size = $0158, fill=yes, fillval=$AA;
 }
 

--- a/cfg/codex-x16.cfgtpl
+++ b/cfg/codex-x16.cfgtpl
@@ -1,11 +1,11 @@
 MEMORY {
 	#include "x16.cfginc"
 
-    MAIN:     file = %O, define = yes, start = $C000, size = $3AE2, fill=yes  fillval=$A3;
+    MAIN:     file = %O, define = yes, start = $C000, size = $3A72, fill=yes  fillval=$A3;
     RWRAM:    file = "",               start = $0400, size = $3FF;
     BANK:     file = "",               start = $A000, size = $2000;
-    CODEX_VECS: start = $FAE2, size = $001E, fill=yes, fillval=$A0;
-    KSUP_CODE2: start = $FB00, size = $03A8, fill=yes, fillval=$A1;
+    CODEX_VECS: start = $FA72, size = $001E, fill=yes, fillval=$A0;
+    KSUP_CODE2: start = $FA80, size = $0418, fill=yes, fillval=$A1;
     KSUP_VEC2:  start = $FEA8, size = $0158, fill=yes, fillval=$A2;
 }
 

--- a/cfg/diag-x16.cfgtpl
+++ b/cfg/diag-x16.cfgtpl
@@ -2,7 +2,7 @@ MEMORY {
 	#include "x16.cfginc"
 
 	JMPTBL: start = $C000, size = $0010, fill = yes, fillval = $00;
-	DIAG:	start = $C010, size = $4000, fill = yes, fillval = $AA;
+	DIAG:	start = $C010, size = $3FF0, fill = yes, fillval = $AA;
 }
 
 SEGMENTS {

--- a/cfg/kernal-x16.cfgtpl
+++ b/cfg/kernal-x16.cfgtpl
@@ -68,7 +68,7 @@ SEGMENTS {
 	VERA_DRV: load = KERNAL,   type = ro;
 	PALETTE:  load = KERNAL,   type = ro, align = $100;
 	KRAMJFAR: load = KERNAL,   run = KRAMJFAR, type = ro, define = yes;
-	KRAMJFAR816: load = KERNAL,   run = KRAMJFAR816, type = ro, define = yes;
+	KJFAR816: load = KERNAL,   run = KJFAR816, type = ro, define = yes;
 	KERNRAM2: load = KERNAL,   run = KERNRAM2, type = ro, define = yes;
 	KRAM816:  load = KERNAL,   run = KRAM816,  type = ro, define = yes;
 	KRAM02B:  load = KERNAL,   run = KRAM02B,  type = ro, define = yes;

--- a/cfg/kernal-x16.cfgtpl
+++ b/cfg/kernal-x16.cfgtpl
@@ -68,6 +68,7 @@ SEGMENTS {
 	VERA_DRV: load = KERNAL,   type = ro;
 	PALETTE:  load = KERNAL,   type = ro, align = $100;
 	KRAMJFAR: load = KERNAL,   run = KRAMJFAR, type = ro, define = yes;
+	KRAMJFAR816: load = KERNAL,   run = KRAMJFAR816, type = ro, define = yes;
 	KERNRAM2: load = KERNAL,   run = KERNRAM2, type = ro, define = yes;
 	KRAM816:  load = KERNAL,   run = KRAM816,  type = ro, define = yes;
 	KRAM02B:  load = KERNAL,   run = KRAM02B,  type = ro, define = yes;

--- a/cfg/monitor-x16.cfgtpl
+++ b/cfg/monitor-x16.cfgtpl
@@ -3,8 +3,8 @@ MEMORY {
 
 	L0220:    start = $0220, size = $0019; # overlaps with top end of BASIC input line only
 
-	BANK5:      start = $C000, size = $3B00, fill=yes, fillval=$AA;
-	KSUP_CODE2: start = $FB00, size = $03A8, fill=yes, fillval=$AA;
+	BANK5:      start = $C000, size = $3A80, fill=yes, fillval=$AA;
+	KSUP_CODE2: start = $FA80, size = $0428, fill=yes, fillval=$AA;
 	KSUP_VEC2:  start = $FEA8, size = $0158, fill=yes, fillval=$AA;
 }
 

--- a/cfg/util-x16.cfgtpl
+++ b/cfg/util-x16.cfgtpl
@@ -4,8 +4,8 @@ MEMORY {
 	HEXEDITZP:   start = $0022, size = $005E, fill=no;
 	HEXEDITBSS:  start = $0200, size = $0050, fill=no;
 	MENUBSS:     start = $0200, size = $0050, fill=no;
-	ROM:         start = $C000, size = $3B00, fill=yes, fillval=$AA;
-	KSUP_CODE11: start = $FB00, size = $03A8, fill=yes, fillval=$AA;
+	ROM:         start = $C000, size = $3A80, fill=yes, fillval=$AA;
+	KSUP_CODE11: start = $FA80, size = $0428, fill=yes, fillval=$AA;
 	KSUP_VEC11:  start = $FEA8, size = $0158, fill=yes, fillval=$AA;
 
 }

--- a/cfg/x16.cfginc
+++ b/cfg/x16.cfginc
@@ -23,8 +23,8 @@ ZPBASIC:  start = $00D4, size = $002B; # BASIC (last byte used: $FE)
 /* $0200-$02FF: always-available variables and RAM code */
 KVAR:     start = $0200, size = $0095; # KERNAL
 KRAM816S: start = $0295, size = $0003; # KERNAL: 65C816: old stack pointer
-KRAMJFAR816: start = $0298, size = $001C; # KERNAL: jsrfar3n
-/*        start = $02B4, size = $000C; # reserved for KERNAL growth */
+KJFAR816: start = $0298, size = $0019; # KERNAL: jsrfar3n
+/*        start = $02B1, size = $000F; # reserved for KERNAL growth */
 I2CMUTEX: start = $02C0, size = $0001; # I2C MUTEX FLAG
 GRAPHVAR: start = $02C1, size = $0003; # GRAPH BANK VARS
 KRAMJFAR: start = $02C4, size = $001E; # KERNAL: jsrfar3

--- a/cfg/x16.cfginc
+++ b/cfg/x16.cfginc
@@ -27,6 +27,7 @@ KRAM816S: start = $0295, size = $0003; # KERNAL: 65C816: old stack pointer
 I2CMUTEX: start = $02C0, size = $0001; # I2C MUTEX FLAG
 GRAPHVAR: start = $02C1, size = $0003; # GRAPH BANK VARS
 KRAMJFAR: start = $02C4, size = $001E; # KERNAL: jsrfar3
+KRAMJFAR816: start = $02C4, size = $001E; # KERNAL: jsrfar3n
 GDRVVEC:  start = $02E4, size = $001C; # framebuffer driver vectors
 
 /* $0300-$0333: vectors */

--- a/cfg/x16.cfginc
+++ b/cfg/x16.cfginc
@@ -23,11 +23,11 @@ ZPBASIC:  start = $00D4, size = $002B; # BASIC (last byte used: $FE)
 /* $0200-$02FF: always-available variables and RAM code */
 KVAR:     start = $0200, size = $0095; # KERNAL
 KRAM816S: start = $0295, size = $0003; # KERNAL: 65C816: old stack pointer
-/*        start = $0298, size = $0028; # reserved for KERNAL growth */
+KRAMJFAR816: start = $0298, size = $001C; # KERNAL: jsrfar3n
+/*        start = $02B4, size = $000C; # reserved for KERNAL growth */
 I2CMUTEX: start = $02C0, size = $0001; # I2C MUTEX FLAG
 GRAPHVAR: start = $02C1, size = $0003; # GRAPH BANK VARS
 KRAMJFAR: start = $02C4, size = $001E; # KERNAL: jsrfar3
-KRAMJFAR816: start = $02C4, size = $001E; # KERNAL: jsrfar3n
 GDRVVEC:  start = $02E4, size = $001C; # framebuffer driver vectors
 
 /* $0300-$0333: vectors */

--- a/inc/banks.inc
+++ b/inc/banks.inc
@@ -20,6 +20,7 @@ BANK_BASLOAD = $0F
 cbdos_flags= $0268
 status     = $0287 ; channel: status byte
 jsrfar3    = $02c4 ; jsrfar: RAM part
+jsrfar3n   = $02c4 ; jsrfar: RAM part, 65C816 native
 jmpfr      = $02df ; jsrfar: core jmp instruction
 imparm     = $82   ; jsrfar: temporary byte
 stavec     = $03b2 ; stash: argument

--- a/inc/banks.inc
+++ b/inc/banks.inc
@@ -20,7 +20,6 @@ BANK_BASLOAD = $0F
 cbdos_flags= $0268
 status     = $0287 ; channel: status byte
 jsrfar3n   = $0298 ; jsrfar: RAM part, 65C816 native
-jmpfrn     = $02b1 ; jsrfarn: core jmp instruction
 jsrfar3    = $02c4 ; jsrfar: RAM part
 jmpfr      = $02df ; jsrfar: core jmp instruction
 imparm     = $82   ; jsrfar: temporary byte

--- a/inc/banks.inc
+++ b/inc/banks.inc
@@ -19,8 +19,9 @@ BANK_BASLOAD = $0F
 ; XXX implementation details and need to go away!
 cbdos_flags= $0268
 status     = $0287 ; channel: status byte
+jsrfar3n   = $0298 ; jsrfar: RAM part, 65C816 native
+jmpfrn     = $02b1 ; jsrfarn: core jmp instruction
 jsrfar3    = $02c4 ; jsrfar: RAM part
-jsrfar3n   = $02c4 ; jsrfar: RAM part, 65C816 native
 jmpfr      = $02df ; jsrfar: core jmp instruction
 imparm     = $82   ; jsrfar: temporary byte
 stavec     = $03b2 ; stash: argument

--- a/inc/jsrfar.inc
+++ b/inc/jsrfar.inc
@@ -130,7 +130,7 @@ jsrfar1n:
 	pla
 	plp        ; original register widths popped immediately before call
 	jsr jmpfr
-	php
+	php        ; preserve flags immediately after return from call
 	sep #$20   ; 8 bit accumulator
 	.A8
 	.I16
@@ -140,7 +140,7 @@ jsrfar1n:
 	lda $02,S  ; overwrite reserved byte
 	sta $03,S  ; with copy of .P
 	pla
-	plp
+	plp        ; restore flags to state immediately after call
 	plp
 	rts
 

--- a/inc/jsrfar.inc
+++ b/inc/jsrfar.inc
@@ -86,14 +86,13 @@ jsrfarn:
 	.A16
 	.I16
 	pha
-	phx
 	phy
 
-	lda $09,S   ; fetch return address
+	lda $07,S   ; fetch return address
 	sta imparm
 	; carry is clear
 	adc #3
-	sta $09,S   ; write back return address+3
+	sta $07,S   ; write back return address+3
 	ldy #1
 	lda (imparm),y
 	sta jmpfr+1
@@ -104,11 +103,10 @@ jsrfarn:
 	.A8
 	.I16
 	lda rom_bank
-	sta $08,S   ; save original bank onto reserved byte
+	sta $06,S   ; save original bank onto reserved byte
 	ldy #3
 	lda (imparm),y
 	ply
-	plx
 	jmp jsrfar3n
 
 ; target is in RAM
@@ -117,16 +115,14 @@ jsrfar1n:
 	.A8
 	.I16
 	lda ram_bank
-	sta $08,S  ; save original bank onto reserved byte
-	iny
-	iny
+	sta $06,S  ; save original bank onto reserved byte
+	lda #3
 	lda (imparm),y
 	sta ram_bank
 	rep #$30   ; 16 bit memory/index
 	.A16
 	.I16
 	ply
-	plx
 	pla
 	plp        ; original register widths popped immediately before call
 	jsr jmpfr

--- a/inc/jsrfar.inc
+++ b/inc/jsrfar.inc
@@ -4,13 +4,18 @@
 ; .word address
 ; .byte bank
 
-	pha             ;reserve 1 byte on the stack
+	php             ;reserve 1 byte on the stack
 	php             ;save registers & status
+
+	clc
+	.byte $e2, $03 ; sep #$03, set carry if 65c816
+	bcs jsrfarn
+
 	pha
 	phx
 	phy
 
-        tsx
+	tsx
 	lda $106,x      ;return address lo
 	sta imparm
 	clc
@@ -64,3 +69,74 @@ jsrfar2:
 	plp
 	plp
 	rts
+
+.pushcpu
+
+.setcpu "65816"
+
+jsrfarn:
+	rep #$30   ; force 16 bit memory/index
+	.A16
+	.I16
+
+	pha
+	phx
+	phy
+
+	lda $0a,S  ; fetch return address
+	sta imparm
+	clc
+	adc #3
+	sta $0a,S  ; write back return address+3
+	ldy #1
+	lda (imparm),y
+	sta jmpfr+1
+	cmp #$c000
+	bcc jsrfar1n
+; target is in ROM
+	sep #$20   ; 8 bit accumulator
+	.A8
+	.I16
+	lda rom_bank
+	sta $09,S  ; save original bank onto reserved byte
+	iny
+	iny
+	lda (imparm),y
+	ply
+	plx
+	jmp jsrfar3n
+
+; target is in RAM
+jsrfar1n:
+	sep #$20   ; 8 bit accumulator
+	.A8
+	.I16
+	lda ram_bank
+	sta $09,S  ; save original bank onto reserved byte
+	iny
+	iny
+	lda (imparm),y
+	sta ram_bank
+	rep #$30   ; 16 bit memory/index (index should still be 16 bit)
+	.A16
+	.I16
+	ply
+	plx
+	pla
+	plp        ; original register widths popped immediately before call
+	jsr jmpfr
+	php
+	sep #$20   ; 8 bit accumulator
+	.A8
+	.I16
+	pha
+	lda $03,S
+	sta ram_bank
+	lda $02,S  ; overwrite reserved byte
+	sta $03,S  ; with copy of .P
+	pla
+	plp
+	plp
+	rts
+
+.popcpu

--- a/inc/jsrfar.inc
+++ b/inc/jsrfar.inc
@@ -11,6 +11,7 @@
 	.byte $e2, $03 ; sep #$03, set carry if 65c816
 	bcs jsrfarn
 
+jsrfare:
 	pha
 	phx
 	phy
@@ -75,7 +76,12 @@ jsrfar2:
 .setcpu "65816"
 
 jsrfarn:
-	rep #$30   ; force 16 bit memory/index
+	clc
+	xce
+	bcc :+
+	xce
+	bra jsrfare
+:	rep #$30   ; force 16 bit memory/index
 	.A16
 	.I16
 

--- a/inc/jsrfar.inc
+++ b/inc/jsrfar.inc
@@ -7,9 +7,9 @@
 	php             ;reserve 1 byte on the stack
 	php             ;save registers & status
 
-	clc
-	.byte $e2, $03 ; sep #$03, set carry if 65c816
-	bcs jsrfarn
+	sec
+	.byte $c2, $03 ; rep #$03, clear carry/z if 65c816
+	bcc jsrfarn
 
 jsrfare:
 	pha
@@ -76,7 +76,7 @@ jsrfar2:
 .setcpu "65816"
 
 jsrfarn:
-	clc
+	; carry is clear
 	xce
 	bcc :+
 	xce

--- a/inc/jsrfar.inc
+++ b/inc/jsrfar.inc
@@ -78,11 +78,15 @@ jsrfar2:
 
 jsrfarn:
 	; carry is clear
+	php
+	sei
 	xce
 	bcc :+
 	xce
+	plp
 	bra jsrfare ; with carry cleared
-:	rep #$31    ; force 16 bit memory/index, clear carry
+:	plp
+	rep #$31    ; force 16 bit memory/index, clear carry
 	.A16
 	.I16
 	pha
@@ -101,7 +105,6 @@ jsrfarn:
 ; target is in ROM
 	sep #$20    ; 8 bit accumulator
 	.A8
-	.I16
 	lda rom_bank
 	sta $06,S   ; save original bank onto reserved byte
 	ldy #3
@@ -113,15 +116,13 @@ jsrfarn:
 jsrfar1n:
 	sep #$20   ; 8 bit accumulator
 	.A8
-	.I16
 	lda ram_bank
 	sta $06,S  ; save original bank onto reserved byte
 	lda #3
 	lda (imparm),y
 	sta ram_bank
-	rep #$30   ; 16 bit memory/index
+	rep #$20   ; 16 bit accumulator
 	.A16
-	.I16
 	ply
 	pla
 	plp        ; original register widths popped immediately before call
@@ -129,7 +130,6 @@ jsrfar1n:
 	php        ; preserve flags immediately after return from call
 	sep #$20   ; 8 bit accumulator
 	.A8
-	.I16
 	pha
 	lda $03,S
 	sta ram_bank

--- a/inc/jsrfar.inc
+++ b/inc/jsrfar.inc
@@ -89,11 +89,11 @@ jsrfarn:
 	phx
 	phy
 
-	lda $0a,S  ; fetch return address
+	lda $09,S  ; fetch return address
 	sta imparm
 	clc
 	adc #3
-	sta $0a,S  ; write back return address+3
+	sta $09,S  ; write back return address+3
 	ldy #1
 	lda (imparm),y
 	sta jmpfr+1
@@ -104,7 +104,7 @@ jsrfarn:
 	.A8
 	.I16
 	lda rom_bank
-	sta $09,S  ; save original bank onto reserved byte
+	sta $08,S  ; save original bank onto reserved byte
 	iny
 	iny
 	lda (imparm),y
@@ -118,7 +118,7 @@ jsrfar1n:
 	.A8
 	.I16
 	lda ram_bank
-	sta $09,S  ; save original bank onto reserved byte
+	sta $08,S  ; save original bank onto reserved byte
 	iny
 	iny
 	lda (imparm),y

--- a/inc/jsrfar.inc
+++ b/inc/jsrfar.inc
@@ -106,8 +106,7 @@ jsrfarn:
 	.I16
 	lda rom_bank
 	sta $08,S   ; save original bank onto reserved byte
-	iny
-	iny
+	ldy #3
 	lda (imparm),y
 	ply
 	plx

--- a/inc/jsrfar.inc
+++ b/inc/jsrfar.inc
@@ -11,6 +11,7 @@
 	.byte $c2, $03 ; rep #$03, clear carry/z if 65c816
 	bcc jsrfarn
 
+	clc
 jsrfare:
 	pha
 	phx
@@ -19,7 +20,7 @@ jsrfare:
 	tsx
 	lda $106,x      ;return address lo
 	sta imparm
-	clc
+	; carry is clear
 	adc #3
 	sta $106,x      ;and write back with 3 added
 	lda $107,x      ;return address hi
@@ -80,8 +81,8 @@ jsrfarn:
 	xce
 	bcc :+
 	xce
-	bra jsrfare
-:	rep #$30   ; force 16 bit memory/index
+	bra jsrfare ; with carry cleared
+:	rep #$30    ; force 16 bit memory/index
 	.A16
 	.I16
 
@@ -89,22 +90,22 @@ jsrfarn:
 	phx
 	phy
 
-	lda $09,S  ; fetch return address
+	lda $09,S   ; fetch return address
 	sta imparm
-	clc
+	; carry is clear
 	adc #3
-	sta $09,S  ; write back return address+3
+	sta $09,S   ; write back return address+3
 	ldy #1
 	lda (imparm),y
 	sta jmpfr+1
 	cmp #$c000
 	bcc jsrfar1n
 ; target is in ROM
-	sep #$20   ; 8 bit accumulator
+	sep #$20    ; 8 bit accumulator
 	.A8
 	.I16
 	lda rom_bank
-	sta $08,S  ; save original bank onto reserved byte
+	sta $08,S   ; save original bank onto reserved byte
 	iny
 	iny
 	lda (imparm),y

--- a/inc/jsrfar.inc
+++ b/inc/jsrfar.inc
@@ -82,10 +82,9 @@ jsrfarn:
 	bcc :+
 	xce
 	bra jsrfare ; with carry cleared
-:	rep #$30    ; force 16 bit memory/index
+:	rep #$31    ; force 16 bit memory/index, clear carry
 	.A16
 	.I16
-
 	pha
 	phx
 	phy

--- a/inc/jsrfar.inc
+++ b/inc/jsrfar.inc
@@ -122,7 +122,7 @@ jsrfar1n:
 	iny
 	lda (imparm),y
 	sta ram_bank
-	rep #$30   ; 16 bit memory/index (index should still be 16 bit)
+	rep #$30   ; 16 bit memory/index
 	.A16
 	.I16
 	ply

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -277,10 +277,11 @@ jsrfar:
 __jmpfr:
 	jmp $ffff
 
-.segment "KJFAR816"
-
 .pushcpu
 .setcpu "65816"
+
+.segment "KJFAR816"
+.assert * = jsrfar3n, error, "jsrfar3n must be at specific address"
 
 ;jsrfar3n:
 	.A8

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -290,7 +290,7 @@ __jmpfr:
 	.A16
 	.I16
 	pla
-	plp             ; restore register widths immediately before call
+	plp             ; restore all flags immediately before call
 	jsr jmpfr
 	php
 	pha
@@ -302,7 +302,7 @@ __jmpfr:
 	sta $03,S       ;...with copy of .P
 	pla
 	plp             ; restore flags from state immediately after call
-	plp             ; including register widths
+	plp
 	rts
 
 .popcpu

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -8,7 +8,7 @@
 .include "io.inc"
 
 .import __KRAMJFAR_LOAD__, __KRAMJFAR_RUN__, __KRAMJFAR_SIZE__
-.import __KRAMJFAR816_LOAD__, __KRAMJFAR816_RUN__, __KRAMJFAR816_SIZE__
+.import __KJFAR816_LOAD__, __KJFAR816_RUN__, __KJFAR816_SIZE__
 .import __KERNRAM2_LOAD__, __KERNRAM2_RUN__, __KERNRAM2_SIZE__
 .import __KRAM816_LOAD__, __KRAM816_RUN__, __KRAM816_SIZE__
 .import __KRAM02B_LOAD__, __KRAM02B_RUN__, __KRAM02B_SIZE__
@@ -140,9 +140,9 @@ ramtas:
 	.A16
 	.I16
 
-	ldx #__KRAMJFAR816_LOAD__
-	ldy #__KRAMJFAR816_RUN__
-	lda #(__KRAMJFAR816_SIZE__ - 1)
+	ldx #__KJFAR816_LOAD__
+	ldy #__KJFAR816_RUN__
+	lda #(__KJFAR816_SIZE__ - 1)
 	mvn #00,#00
 
 	ldx #__KRAM816_LOAD__
@@ -277,7 +277,7 @@ jsrfar:
 __jmpfr:
 	jmp $ffff
 
-.segment "KRAMJFAR816"
+.segment "KJFAR816"
 
 .pushcpu
 .setcpu "65816"
@@ -303,9 +303,6 @@ __jmpfr:
 	plp
 	plp
 	rts
-.assert * = jmpfrn, error, "jmpfrn must be at specific address"
-__jmpfrn:
-	jmp $ffff
 
 .popcpu
 

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -100,8 +100,6 @@ ramtas:
 	dex
 	bne :-
 
-	set_carry_if_65c816
-	bcs @kernram2_65c816
 ;
 ; copy banking code into RAM
 ;
@@ -110,6 +108,9 @@ ramtas:
 	sta __KRAMJFAR_RUN__-1,x
 	dex
 	bne :-
+
+	set_carry_if_65c816
+	bcs @kernram2_65c816
 
 	ldx #<__KERNRAM2_SIZE__
 
@@ -302,9 +303,7 @@ __jmpfr:
 	plp
 	plp
 	rts
-	nop
-	nop
-.assert * = jmpfr, error, "jmpfrn must be at specific address"
+.assert * = jmpfrn, error, "jmpfrn must be at specific address"
 __jmpfrn:
 	jmp $ffff
 

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -290,19 +290,19 @@ __jmpfr:
 	.A16
 	.I16
 	pla
-	plp
+	plp             ; restore register widths immediately before call
 	jsr jmpfr
 	php
 	pha
-	sep #$20        ; 8 bit accumulator
+	sep #$20        ; 8 bit accumulator (we don't care about index width)
 	.A8
 	lda $03,S
 	sta rom_bank    ;restore ROM bank
 	lda $02,S       ;overwrite reserved byte...
-	sta $03,S       ;...with copy of .p
+	sta $03,S       ;...with copy of .P
 	pla
-	plp
-	plp
+	plp             ; restore flags from state immediately after call
+	plp             ; including register widths
 	rts
 
 .popcpu

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -293,14 +293,14 @@ __jmpfr:
 	plp             ; restore all flags immediately before call
 	jsr jmpfr
 	php
-	pha
-	sep #$20        ; 8 bit accumulator (we don't care about index width)
+	sep #$20        ; 8 bit accumulator
 	.A8
+	pha             ; Push lower byte of accumulator
 	lda $03,S
 	sta rom_bank    ;restore ROM bank
 	lda $02,S       ;overwrite reserved byte...
 	sta $03,S       ;...with copy of .P
-	pla
+	pla             ; .B remains unchanged and is thus preserved
 	plp             ; restore flags from state immediately after call
 	plp
 	rts

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -285,10 +285,10 @@ __jmpfr:
 
 ;jsrfar3n:
 	.A8
-	sta rom_bank    ;set ROM bank
-	rep #$30
-	.A16
 	.I16
+	sta rom_bank    ;set ROM bank
+	rep #$20
+	.A16
 	pla
 	plp             ; restore all flags immediately before call
 	jsr jmpfr


### PR DESCRIPTION
The native RAM code is 2 bytes shorter due to the savings in size from stack-relative addressing, even with the added SEP/REP