### PR TITLE
[DIAG] fix memory region size so as not to overrun 16kB

### DIFF
--- a/cfg/diag-x16.cfgtpl
+++ b/cfg/diag-x16.cfgtpl
@@ -2,7 +2,7 @@ MEMORY {
 	#include "x16.cfginc"
 
 	JMPTBL: start = $C000, size = $0010, fill = yes, fillval = $00;
-	DIAG:	start = $C010, size = $4000, fill = yes, fillval = $AA;
+	DIAG:	start = $C010, size = $3FF0, fill = yes, fillval = $AA;
 }
 
 SEGMENTS {


### PR DESCRIPTION
bank 16 (the final bank) was overrunning 16KB, which, while not a real issue while it's the final bank, was causing validation errors in x16-flash