### PR TITLE
[KERNAL] use dedicated tmp memory location for kbd_scan

### DIFF
--- a/cfg/kernal-x16.cfgtpl
+++ b/cfg/kernal-x16.cfgtpl
@@ -10,6 +10,7 @@ MEMORY {
 SEGMENTS {
 	ZPKERNAL:   load = ZPKERNAL, type = zp;
 	ZPCHANNEL:  load = ZPKERNAL, type = zp;
+	ZPKBD:      load = ZPKERNAL, type = zp;
 	ZPFONTS:    load = ZPKERNAL, type = zp;
 
 	KVAR:       load = KVAR,     type = bss;

--- a/cfg/x16.cfginc
+++ b/cfg/x16.cfginc
@@ -13,9 +13,9 @@
 
 /* zero page */
 /*        start = $0000, size = $0080; # available to the user */
-ZPKERNAL: start = $0080, size = $0010; # KERNAL
-ZPDOS:    start = $0090, size = $000B; # DOS
-/*        start = $009B, size = $000C; # reserved for DOS or BASIC growth */
+ZPKERNAL: start = $0080, size = $0011; # KERNAL
+ZPDOS:    start = $0091, size = $000B; # DOS
+/*        start = $009C, size = $000B; # reserved for DOS or BASIC growth */
 ZPAUDIO:  start = $00A7, size = $0002; # AUDIO
 ZPMATH:   start = $00A9, size = $002B; # MATH
 ZPBASIC:  start = $00D4, size = $002B; # BASIC (last byte used: $FE)


### PR DESCRIPTION
`tmp2` is in flux outside of `kbd_scan`, and it wasn't preserved by `kbd_scan`, so there was a potential race where `kbd_scan` in the ISR modified tmp2, corrupting state in the main part of the kernal if it happened to rely on the value of `tmp2`.

This change gives `kbd_scan` its own dedicated space for this temporary byte.