### PR TITLE
[KERNAL] rearrange segment layout to better fit

### DIFF
--- a/cfg/kernal-x16.cfgtpl
+++ b/cfg/kernal-x16.cfgtpl
@@ -34,9 +34,7 @@ SEGMENTS {
 	PS2KBD:   load = KERNAL,   type = ro;
 	PS2MOUSE: load = KERNAL,   type = ro;
 	SERIAL:   load = KERNAL,   type = ro;
-	MEMORY:   load = KERNAL,   type = ro;
 	LZSA:     load = KERNAL,   type = ro;
-	RS232:    load = KERNAL,   type = ro;
 	CHANNEL:  load = KERNAL,   type = ro;
 	C816_UTIL: load = KERNAL,  type = ro;
 	C816_ABORT_NATIVE: load = KERNAL, type = ro, start = $E44C; # low byte: JMP abs, high byte equals low byte of C816_CLALL_THUNK
@@ -48,9 +46,11 @@ SEGMENTS {
 	C816_CLALL_THUNK: load = KERNAL, type = ro, start = $EAE4;  # low byte equals high byte of C816_ABORT_NATIVE, high byte = NOP
 	C816_BRK: load = KERNAL, type = ro, start = $EAE7;        # low byte equals high byte of C816_GETIN_THUNK, high byte = nop
 	C816_NMIB: load = KERNAL, type = ro, start = $EAEA;         # low byte equals NOP and high byte of C816_CLALL_THUNK, high byte = NOP
+	MEMORY:   load = KERNAL,   type = ro;
 	C816_COP_NATIVE: load = KERNAL, type = ro, start = $EF4C; # low byte: JMP abs, high byte equals low byte of C816_GETIN_THUNK
 	C816_COP_EMULATED: load = KERNAL, type = ro;
 	C816_ABORT_EMULATED: load = KERNAL, type = ro;
+	RS232:    load = KERNAL,   type = ro;
 	KBDBUF:   load = KERNAL,   type = ro;
 	CLOCK:    load = KERNAL,   type = ro;
 	I2C:      load = KERNAL,   type = ro;


### PR DESCRIPTION
As segments have expanded, they've tended to bump up against the fixed 65C816 support locations.  This arrangement should help a little bit w/ the rest of the immediate expansion needed.