### PR TITLE
[BASIC] fix VPOKE pointer preservation

### DIFF
--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -247,7 +247,16 @@ vpeek	jsr chrget
 vpoke	jsr getbyt ; bank
 	phx
 	jsr chkcom
-	jsr getnum
+	jsr frmadr
+	lda poker+1
+	pha
+	lda poker
+	pha
+	jsr combyt
+	pla
+	sta poker
+	pla
+	sta poker+1
 	pla
 	cmp #4
 	bcs @io4


### PR DESCRIPTION
The `poker` preservation logic was moved out of `PEEK` and into `POKE` in #275 which solved the memory clobbering error when using `POINTER()` and `STRPTR()` inside expressions for `POKE`, but unfortunately it broke pointer expressions inside of `VPOKE`.