### PR TITLE
[KERNAL] fix old CBM porting bug which assumed color variable was 0-15 for unconditional branch

### DIFF
--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -778,8 +778,7 @@ bk2	lda #' '
 	jsr screen_set_char
 	lda color
 	jsr screen_set_color
-	bmi ntcn1
-	jmp jpl3
+	jmp loop2
 ntcn1	ldx qtsw
 	beq nc3w
 	bit mode


### PR DESCRIPTION
The original C64 code did this

![image](https://github.com/X16Community/x16-rom/assets/395186/8c1565a3-4a43-4180-bf5f-1cf95d574f87)

The `color` variable on C64 is limited to 0-15, so the location is always positive.  The original C64 source code was using `bpl` as an unconditional branch. The X16 uses the high nibble for the background color (or colors >= $80 in T256C mode), so this is no longer a good assumption.

In the course of X16 development, the branch became too far away, so the sense was inverted, but the logic was still incorrect.

Changed it to a `jmp` instead.

Closes #338 