### PR TITLE
[GRAPH] FB_set_8_pixels(_opaque) did not handle VRAM addresses > 0x0ffff

### DIFF
--- a/graphics/drivers/framebuffer.s
+++ b/graphics/drivers/framebuffer.s
@@ -288,14 +288,10 @@ FB_set_8_pixels:
 	sec
 	rol
 	bcs @2
-	inc VERA_ADDR_L
-	bne @1
-	inc VERA_ADDR_M
+	bit VERA_DATA0
 @1:	asl
 	bcs @2
-	inc VERA_ADDR_L
-	bne @1
-	inc VERA_ADDR_M
+	bit VERA_DATA0
 	bra @1
 @2:	beq @3
 	stx VERA_DATA0
@@ -331,9 +327,7 @@ FB_set_8_pixels_opaque:
 @2:	stx VERA_DATA0
 	bra @1
 @3:	asl r0L
-	inc VERA_ADDR_L
-	bne @1
-	inc VERA_ADDR_M
+	bit VERA_DATA0
 	bra @1
 @4:	rts
 


### PR DESCRIPTION
The ADDR0 is set to auto-increment by the cursor position set , so a read op is enough to increment the ADDR0 pointer (and is faster to boot)

Closes #340 