### PR TITLE
[KERNAL] 65C816 native NMI sets up for native return from emulated call

### DIFF
--- a/kernal/x16/65c816/interrupt.s
+++ b/kernal/x16/65c816/interrupt.s
@@ -55,7 +55,7 @@ rom_bank = 1
 	.I8
 .endmacro
 
-.macro irq_brk_common_impl addr, emulated_kernal_vector, emulated_kernal_impl
+.macro intr_common_impl addr, emulated_kernal_vector, emulated_kernal_impl
 	.A16
 	.I16
 	tsx
@@ -83,6 +83,10 @@ rom_bank = 1
 	clc
 
 	php
+.endmacro
+
+.macro irq_brk_common_impl addr, emulated_kernal_vector, emulated_kernal_impl
+	intr_common_impl addr, emulated_kernal_vector, emulated_kernal_impl
 
 	lda $0B, S
 	pha
@@ -178,7 +182,7 @@ __interrupt_65c816_native_kernal_impl_ret:
 
 nnnmi:
 	c816_interrupt_impl
-	irq_brk_common_impl
+	intr_common_impl
 	jmp nmi
 
 nncop:

--- a/kernal/x16/65c816/interrupt.s
+++ b/kernal/x16/65c816/interrupt.s
@@ -95,6 +95,7 @@ rom_bank = 1
 	lda $07, S
 	pha
 
+	jmp (addr)
 .endmacro
 
 .segment "C816_COP_EMULATED"
@@ -160,11 +161,9 @@ __irq_65c816_first:
 
 nnirq:
 	irq_brk_common_impl cinv, key, irq_emulated_impl
-	jmp (cinv)
 
 nnbrk:
-	irq_brk_common_impl
-	jmp (cbinv)
+	irq_brk_common_impl cbinv
 
 __interrupt_65c816_native_ret:
 	clc


### PR DESCRIPTION
This change causes the default native NMI indirect vector target to switch to emulation mode while setting up an RTI stack frame, giving an emulation NMI handler that is 65C816-unaware the ability to return back into native code.

Removed the explicit jump from one of the irq handling macros to make them more general so that the routine could be reused.