### PR TITLE
[MATH] modify fdiv to support 65C816 native mode

### DIFF
--- a/math/code19.s
+++ b/math/code19.s
@@ -143,7 +143,8 @@ bfdivt
 	jsr muldiv	;fix up exponents.
 	inc facexp	;scale it right.
 	beq goover	;overflow.
-	ldx #253-addprc	;set up procedure.
+	ldx #256-addprc	;set up procedure. (modified to avoid ZP wrap
+	               	;to allow for 65C816 native mode use)
 	lda #1
 divide			;this is the best code in the whole pile.
 	ldy argho	;see what relation holds.
@@ -162,9 +163,10 @@ savquo
 	rol a		;save result.
 	bcc qshft	;if not done, continue.
 	inx
-	sta reslo,x
+	sta resho,x	;modified as above to keep X positive
+	cpx #3		;to allow for 65C816 native mode compat
 	beq ld100
-	bpl divnrm	;note this req 1 no ram then access.
+	bcs divnrm	;note this req 1 no ram then access.
 	lda #1
 qshft
 	plp		;return condition codes.


### PR DESCRIPTION
The constant `addprc` is present in most Microsoft BASICs of the era from which this code was ported, and in other references this constant means "additional precision".  On the C64, and hence the X16, this constant was set to 1.

For the issue at hand, the X register was set to `#252`, and then incremented before the store of the first byte on (pre-diff) line 165, which set the index to 253, (or with ZP wraparound, -3) relative to `reslo`, which is `resho`, or the first byte of the FP result quintet.

The negative offset was a useful space and cycle saving measure as it allowed the code to skip a compare instruction after incrementing X, but allow a branch for 0 and then for 1.  Unfortunately, when attempting to use this in native mode on the 65C816, where the ZP wraparound behavior is absent, you'd cause corruption and garbage writing to the wrong address.

This change begins the X register's role in `fdiv` at 255, which is incremented to 0 before the first use, which (post-diff) stores the value of A to resho just like before.  However, now we have added the compare instruction that allows our checks to branch for the 4th and 5th bytes respectively, just like before, but without depending on ZP wraparound behavior.