### PR TITLE
Move typematic rate/delay setting from Kernal init

### DIFF
--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -249,14 +249,6 @@ cint	jsr iokeys
 @l2
 	jsr kbd_config  ;set keyboard layout
 
-	jsr fetch_typematic_from_nvram
-	bmi @l3
-	tax
-	lda #6
-	jsr extapi
-
-@l3
-
 	lda #$c
 	sta blnct
 	sta blnsw

--- a/kernal/drivers/x16/ps2data.s
+++ b/kernal/drivers/x16/ps2data.s
@@ -18,6 +18,7 @@ PS2DATA_OLD_STYLE = $01
 PS2DATA_NEW_STYLE = $02
 
 .import i2c_read_byte, i2c_read_first_byte, i2c_direct_read, i2c_read_next_byte, i2c_read_stop, i2c_write_byte
+.import tpmflg
 .export ps2data_init, ps2data_fetch, ps2data_kbd, ps2data_kbd_count, ps2data_mouse, ps2data_mouse_count
 .export ps2data_keyboard_and_mouse, ps2data_keyboard_only, ps2data_raw
 
@@ -38,9 +39,12 @@ PS2DATA_NEW_STYLE = $02
 ;         Data fecth method stored in ps2data_style
 ;         - SMC version < 46.0.0 => PS2DATA_OLD_STYLE
 ;         - SMC version >= 46.0.0 => PS2DATA_NEW_STYLE
-;---------------------------------------------------------------
+;----------------------	-----------------------------------------
 ps2data_init:
 	KVARS_START
+
+	; Clear keyboard set typematic rate/delay flag
+	stz tpmflg
 
 	; Compare SMC firmare version major
 	ldx #I2C_ADDR


### PR DESCRIPTION
It's been reported in the SMC channel on Discord that some keyboards will not light up the Num Lock LED on boot if you have set keyboard typematic rate/delay in the MENU config. This at least happens with the official Perrix keyboard.

I don't have access to that keyboard to take any data samples, but the issue is likely caused by the Kernal sending the set typematic rate/delay command during keyboard POR or when the SMC is sending the set LEDs command.

The keyboard POR should according to IBM specs take minimum 150 ms and maximum 2.0 s. It might therefore differ a lot how long the POR takes.

To remove the risk that there is interference between the SMC keyboard init and the Kernal init, I suggest that we remove the set typematic rate/delay from Kernal init. We could move it to the keyboard driver and send the setting after receiving the first key code.