### PR TITLE
[BASIC] Replace ldy #0 + (zp),y addressing with (zp) addressing

### DIFF
--- a/basic/code17.s
+++ b/basic/code17.s
@@ -254,8 +254,7 @@ mlex10
 	adc tenexp	;like multiplying by five.
 	asl a		;and now by ten.
 	clc
-	ldy #0
-	adc (txtptr),y
+	adc (txtptr)
 	sec
 	sbc #'0'
 mlexmi

--- a/basic/code17.s
+++ b/basic/code17.s
@@ -49,7 +49,7 @@ peek	jsr getadr0
 	lda poker+1
 	cmp #$a0
 	bcs peek1
-	lda (poker),y   ;Low RAM
+	lda (poker)   ;Low RAM
 	jmp peek2
 peek3	stz ram_bank
 	ldx crombank

--- a/basic/code17.s
+++ b/basic/code17.s
@@ -21,15 +21,13 @@ val_str	bne @1
 	bcc val2
 	inx
 val2	stx index2+1
-	ldy #0
 	lda (index2)
 	pha
-	tya             ;a=0
+	lda #0
 	sta (index2)
 	jsr chrgot
 	jsr finh
 	pla
-	ldy #0
 	sta (index2)
 st2txt	ldx strng2
 	ldy strng2+1
@@ -45,7 +43,6 @@ getadr0	jsr getadr
 	sta poker+1
 	rts
 peek	jsr getadr0
-	ldy #0
 	lda poker+1
 	cmp #$a0
 	bcs peek1
@@ -59,7 +56,8 @@ peek3	stz ram_bank
 peek1	cmp #$c0
 	bcs peek3
 	ldx crambank
-peek4	lda #poker	;High RAM or ROM
+peek4	ldy #0
+	lda #poker	;High RAM or ROM
 	jsr fetch
 peek2	tay
 dosgfl	jmp sngflt
@@ -76,7 +74,6 @@ poke	jsr frmadr
 	cmp #$a0
 	bcs pokefr
 	txa
-	ldy #0
 	sta (poker)
 	rts
 pokefr2	stz ram_bank
@@ -100,7 +97,6 @@ fnwait	jsr getnum
 	beq stordo
 	jsr combyt
 stordo	stx eormsk
-	ldy #0
 waiter	lda (poker)
 	eor eormsk
 	and andmsk

--- a/basic/code17.s
+++ b/basic/code17.s
@@ -22,15 +22,15 @@ val_str	bne @1
 	inx
 val2	stx index2+1
 	ldy #0
-	lda (index2),y
+	lda (index2)
 	pha
 	tya             ;a=0
-	sta (index2),y
+	sta (index2)
 	jsr chrgot
 	jsr finh
 	pla
 	ldy #0
-	sta (index2),y
+	sta (index2)
 st2txt	ldx strng2
 	ldy strng2+1
 	stx txtptr

--- a/basic/code17.s
+++ b/basic/code17.s
@@ -77,7 +77,7 @@ poke	jsr frmadr
 	bcs pokefr
 	txa
 	ldy #0
-	sta (poker),y
+	sta (poker)
 	rts
 pokefr2	stz ram_bank
 	txa

--- a/basic/code17.s
+++ b/basic/code17.s
@@ -101,7 +101,7 @@ fnwait	jsr getnum
 	jsr combyt
 stordo	stx eormsk
 	ldy #0
-waiter	lda (poker),y
+waiter	lda (poker)
 	eor eormsk
 	and andmsk
 	beq waiter


### PR DESCRIPTION
As the original NMOS 6502 didn't have `(zp)` addressing, it used `(zp),y` addressing with a constant .Y = 0 for ZP indirect loads. Not only is this not necessary anymore, as both our target CPUs support `(zp)` addressing, it leads to behavior differences when `POKE` is used on addresses in the IO page:  In the extra CPU cycle needed to calculate the target address during `sta (zp),y`, the 65C816 performs a read of an invalid address, while the 65C02 performs a read of what is presumed to be the last fetched instruction byte, causing an extra read from the IO page on the 65C816.

This PR replaces all unnecessary `(zp),y` usages in code17.s, where the implementation for `PEEK` and `POKE` lives.