### PR TITLE
[KERNAL] PRIMM: Add 65C816 native mode support and optimize the code

### DIFF
--- a/cfg/kernal-x16.cfgtpl
+++ b/cfg/kernal-x16.cfgtpl
@@ -36,6 +36,7 @@ SEGMENTS {
 	SERIAL:   load = KERNAL,   type = ro;
 	LZSA:     load = KERNAL,   type = ro;
 	CHANNEL:  load = KERNAL,   type = ro;
+	UTIL:     load = KERNAL,   type = ro;
 	C816_UTIL: load = KERNAL,  type = ro;
 	C816_ABORT_NATIVE: load = KERNAL, type = ro, start = $E44C; # low byte: JMP abs, high byte equals low byte of C816_CLALL_THUNK
 	JOYSTICK: load = KERNAL,   type = ro;
@@ -61,7 +62,6 @@ SEGMENTS {
 	MEMDRV:   load = KERNAL,   type = ro;
 	NMI:      load = KERNAL,   type = ro;
 	IRQ:      load = KERNAL,   type = ro;
-	UTIL:     load = KERNAL,   type = ro;
 	GRAPH:    load = KERNAL,   type = ro;
 	CONSOLE:  load = KERNAL,   type = ro;
 	SPRITES:  load = KERNAL,   type = ro;

--- a/kernal/cbm/util.s
+++ b/kernal/cbm/util.s
@@ -21,55 +21,70 @@ bsout = $ffd2
 ;  terminated by a $00. the immediate string must not be longer
 ;  than 255 characters including the terminator.
 
-primm
+.proc primm
 	pha             ;save registers
 	phx
+	phy
+	ldy #0
 
 	set_carry_if_65c816
-	bcs @is_65c816
+	bcs is_65c816
 
-@1	tsx             ;increment return address on stack
-	inc $103,x      ;and make imparm = return address
-	bne @2
-	inc $104,x
-@2	lda $103,x
+	tsx
+	lda $0104,x
 	sta imparm
-	lda $104,x
+	lda $0105,x
 	sta imparm+1
 
-	lda (imparm)    ;fetch character to print (*** always system bank ***)
-	beq @3          ;null= eol
-	jsr bsout       ;print the character
+@1	iny
+	lda (imparm),y ;fetch character to print (*** always system bank ***)
+	beq @2         ;null= eol
+	jsr bsout      ;print the character
 	bcc @1
 
-@3	plx             ;restore registers
+@2	phy            ;increment return address on stack
+	tsx
+	lda imparm
+	clc
+	adc $0101,x
+	sta $0105,x
+	bcc @3
+	lda imparm+1
+	adc #$00
+	sta $0106,x
+@3	ply            ;pop counter
+	ply            ;restore registers
+	plx
 	pla
-	rts             ;return
+	rts
 
-@is_65c816
+is_65c816:
 .pushcpu
 .setcpu "65816"
-	phy
-	ldy #$0
-@4	iny
-	lda ($04,S),y  ;fetch character to print (*** always system bank ***)
-	beq @5         ;null= eol
-	jsr bsout      ;print the character
-	bcc @4
-
-@5
-	phy            ;increment return address on stack
+	lda $04,S
+	sta imparm
 	lda $05,S
+	sta imparm+1
+
+@1	iny
+	lda (imparm),y ;fetch character to print (*** always system bank ***)
+	beq @2         ;null= eol
+	jsr bsout      ;print the character
+	bcc @1
+
+@2	phy            ;increment return address on stack
+	lda imparm
 	clc
 	adc $01,S
 	sta $05,S
-	bcc @6
-	lda $06,S
+	bcc @3
+	lda imparm+1
 	adc #$00
 	sta $06,S
-@6	ply            ;pop counter
+@3	ply            ;pop counter
 	ply            ;restore registers
 	plx
 	pla
 	rts
 .popcpu
+.endproc


### PR DESCRIPTION
PRIMM is the only KERNAL library function left that uses abs,x addressing for stack access, thereby not working with a 65C816 in native mode where the stack page might have been moved. This PR adds an implementation that uses the 65C816's stack-relative addressing to work with arbitrary stack pointers; it also optimizes the 65C02's code path.