### PR TITLE
[FAT32] Avoid indexed access with base in IO range on 65C816

### DIFF
--- a/fat32/fat32.s
+++ b/fat32/fat32.s
@@ -3199,7 +3199,7 @@ x16_banked_copy:
 	jmp fat32_read_cont1
 @wrapped:
 	inx ; wrap bank
-	; ended on wrap boundary
+	; ended on wrap boundary?
 	cpy tmp_done
 	beq @end_banked_read
 	; in order to avoid an indexed write into I/O space
@@ -3527,7 +3527,7 @@ fat32_write:
 	; in order to avoid an indexed read from I/O space
 	; on the 65C816, which could have side effects, we
 	; resort to an alternate method here which avoids
-	; this condition, and is at least a cycle shorter
+	; this condition, and is at least two cycles shorter
 	; in the loop construct, not counting the setup
 
 	; save old ptr low byte

--- a/fat32/fat32.s
+++ b/fat32/fat32.s
@@ -3523,7 +3523,7 @@ fat32_write:
 @nowrap:
 	cpy tmp_done
 	bne @loop
-@end_banked_read:
+@end_banked_write:
 	; restore temporary zero page
 	stx bank_save
 	pla
@@ -3534,7 +3534,7 @@ fat32_write:
 @816_9f_page:
 	; early exit
 	cpy tmp_done
-	beq @end_banked_read
+	beq @end_banked_write
 	; in order to avoid an indexed read from I/O space
 	; on the 65C816, which could have side effects, we
 	; resort to an alternate method here which avoids
@@ -3566,7 +3566,7 @@ fat32_write:
 	sta fat32_ptr
 	pla
 	sta fat32_ptr+1
-	bra @end_banked_read
+	bra @end_banked_write
 
 
 ;-----------------------------------------------------------------------------

--- a/fat32/fat32.s
+++ b/fat32/fat32.s
@@ -8,6 +8,7 @@
 .include "lib.inc"
 .include "sdcard.inc"
 .include "text_input.inc"
+.include "65c816.inc"
 
 .import sector_buffer, sector_buffer_end, sector_lba, sdcard_set_fast_mode
 
@@ -3189,9 +3190,12 @@ x16_banked_copy:
 	inx
 	lda #$9f
 	sta fat32_ptr+1
+	set_carry_if_65c816
+	bcs @816_9f_page
 @nowrap:
 	cpy tmp_done
 	bne @loop
+@end_banked_read:
 	; restore temporary zero page
 	stx bank_save
 	pla
@@ -3199,6 +3203,42 @@ x16_banked_copy:
 	pla
 	sta krn_ptr1
 	jmp fat32_read_cont1
+@816_9f_page:
+	; early exit
+	cpy tmp_done
+	beq @end_banked_read
+	; in order to avoid an indexed write into I/O space
+	; on the 65C816, which could have side effects, we
+	; resort to an alternate method here which avoids
+	; this condition, and is at least two cycles shorter
+	; in the loop construct, not counting the setup
+
+	; save old ptr
+	lda fat32_ptr+1
+	pha
+	lda fat32_ptr
+	pha
+
+	stz fat32_ptr
+	lda #$a0
+	sta fat32_ptr+1
+@wrapped_loop:
+	lda (fat32_bufptr),y
+	stx ram_bank
+	sta (fat32_ptr)
+	stz ram_bank
+	iny
+	; we will always have less than 256 bytes to copy
+	; before loop end here, so we only ever need to increment
+	; the low byte of the destination ptr
+	inc fat32_ptr
+	cpy tmp_done
+	bne @wrapped_loop
+	pla
+	sta fat32_ptr
+	pla
+	sta fat32_ptr+1
+	bra @end_banked_read
 
 x16_stream_copy:
 	; move Y (bytecnt) into X for countdown
@@ -3478,9 +3518,12 @@ fat32_write:
 	inx
 	lda #$9f
 	sta fat32_ptr+1
+	set_carry_if_65c816
+	bcs @816_9f_page
 @nowrap:
 	cpy tmp_done
 	bne @loop
+@end_banked_read:
 	; restore temporary zero page
 	stx bank_save
 	pla
@@ -3488,6 +3531,42 @@ fat32_write:
 	pla
 	sta krn_ptr1
 	jmp @4c
+@816_9f_page:
+	; early exit
+	cpy tmp_done
+	beq @end_banked_read
+	; in order to avoid an indexed read from I/O space
+	; on the 65C816, which could have side effects, we
+	; resort to an alternate method here which avoids
+	; this condition, and is at least a cycle shorter
+	; in the loop construct, not counting the setup
+
+	; save old ptr
+	lda fat32_ptr+1
+	pha
+	lda fat32_ptr
+	pha
+
+	stz fat32_ptr
+	lda #$a0
+	sta fat32_ptr+1
+@wrapped_loop:
+	stx ram_bank
+	lda (fat32_ptr)
+	stz ram_bank
+	sta (fat32_bufptr),y
+	iny
+	; we will always have less than 256 bytes to copy
+	; before loop end here, so we only ever need to increment
+	; the low byte of the source ptr
+	inc fat32_ptr
+	cpy tmp_done
+	bne @wrapped_loop
+	pla
+	sta fat32_ptr
+	pla
+	sta fat32_ptr+1
+	bra @end_banked_read
 
 
 ;-----------------------------------------------------------------------------

--- a/fat32/fat32.s
+++ b/fat32/fat32.s
@@ -3201,7 +3201,7 @@ x16_banked_copy:
 	inx ; wrap bank
 	; ended on wrap boundary?
 	cpy tmp_done
-	beq @end_banked_read
+	beq @end_wrapped
 	; in order to avoid an indexed write into I/O space
 	; on the 65C816, which could have side effects, we
 	; resort to an alternate method here which avoids
@@ -3229,6 +3229,7 @@ x16_banked_copy:
 	bne @wrapped_loop
 	pla
 	sta fat32_ptr
+@end_wrapped:
 	lda #$9f
 	sta fat32_ptr+1
 	bra @end_banked_read
@@ -3523,7 +3524,7 @@ fat32_write:
 	inx ; wrap bank
 	; ended on wrap boundary?
 	cpy tmp_done
-	beq @end_banked_write
+	beq @end_wrapped
 	; in order to avoid an indexed read from I/O space
 	; on the 65C816, which could have side effects, we
 	; resort to an alternate method here which avoids
@@ -3551,6 +3552,7 @@ fat32_write:
 	bne @wrapped_loop
 	pla
 	sta fat32_ptr
+@end_wrapped:
 	lda #$9f
 	sta fat32_ptr+1
 	bra @end_banked_write


### PR DESCRIPTION
Bank area blockwise reads and writes which wrap RAM banks in the middle of the read or write operation formerly used indirect indexed mode in $9Fxx,y to continue the operation, where .Y would start with the offset to put the first byte at $A000. 

This change prevents that condition on the 65C816.

Backstory:

On the 65C816, when doing indexed reads and writes, the cycle immediately before the valid operation is a read of the indexed offset without carry.

For instance

```
ldy #$80
lda $9f80,y
```
For the `lda` instruction on the 65C816, just like on the original 6502, the CPU will first add .Y to the address without carry, and do a read cycle.  This will read from `$9f00`.  If the page wrapped, the CPU will do another cycle, and on this the carry of the wrap will be added to the effective address, and will do the actual read from `$a000` and continue execution.

In the FAT32 code, this is done via indirect, but the effect is the same
```
lda #$9f
sta ptr+1
stz ptr
ldy #$80
lda (ptr),y
```

The `lda` instruction on the '816 will dereference `ptr`, and then do the exact same read cycle as above.

For stores, the process is similar, but slightly different

```
ldy #$80
lda #$69
sta $9f80,y
```
On the first cycle, just like above .Y will be added to the effective address without carry, and the CPU will always do a read cycle on the resulting address, even if the page did not wrap.  On the next cycle, any carry will be applied and the CPU will do a write cycle on the effective address.

Indirect has the same cycle pattern after dereferencing.

Of note, an indexed write will always have that extra read cycle, otherwise in the case of a page wrap, the extra cycle will have affected the wrong address.  The CPU assumes that the read doesn't have a side effect.