### PR TITLE
[BASIC] Fix 1E39 bug (Issue #247)

### DIFF
--- a/basic/code17.s
+++ b/basic/code17.s
@@ -30,14 +30,14 @@ val1	ldx txtptr
 	bcc val2
 	inx
 val2	stx strng2+1
-	lda (strng2),y	;replace character after string with $00 (fake eol)
+	lda (strng2)	;replace character after string with $00 (fake eol)
 	pha
 	lda #0
-	sta (strng2),y
+	sta (strng2)
 	jsr chrgot
 	jsr finh		;go do evaluation
 	pla				;get pres'd character.
-	sta (strng2),y	;restore zeroed-out character
+	sta (strng2)	;restore zeroed-out character
 st2txt	ldx strng2	;restore text pointer
 	ldy strng2+1
 	stx txtptr

--- a/basic/code17.s
+++ b/basic/code17.s
@@ -13,7 +13,7 @@ val	jsr len1        ;get length
 val_str	bne @1      ;return 0 if len=0
 	jmp zerofc
 @1:	cmp #254        ;check if string is =>255 chars (including null)
-	bne zerofc      ;yes, return 0
+	bne val_strlong ;yes, return 0
 	ldx txtptr      ;save current txtptr
 	ldy txtptr+1
 	phy
@@ -53,12 +53,13 @@ val_str	bne @1      ;return 0 if len=0
 	ply
 	stx index1
 	sty index1+1
-	rts           ;done!
-st2txt	ldx strng2	;restore text pointer
+	rts            ;done!
+st2txt	ldx strng2 ;restore text pointer
 	ldy strng2+1
 	stx txtptr
 	sty txtptr+1
-valrts	rts			;done!
+valrts	rts        ;done!
+val_strlong	jmp zerofc
 getnum	jsr frmadr
 combyt	jsr chkcom
 	jmp getbyt

--- a/basic/code17.s
+++ b/basic/code17.s
@@ -16,7 +16,6 @@ val_str	bne @1      ;return 0 if len=0
 	ldy txtptr+1
 	phy
 	phx
-	stx index2+1
 	ldx index1      ;save current index1
 	ldy index1+1
 	phy

--- a/basic/code17.s
+++ b/basic/code17.s
@@ -5,6 +5,9 @@ conint	jsr posint
 	ldx faclo
 	jmp chrgot
 
+len2    .res 1
+val_strptr  .res 2
+
 ; the "val" function takes a string and turns it into a number by interpreting
 ; the ascii digits etc. Except for the problem that a terminator must be
 ; supplied by replacing the character beyond the string, VAL is merely a call
@@ -12,37 +15,35 @@ conint	jsr posint
 val	jsr len1		;get length
 val_str	bne val1	;return 0 if len=0
 	jmp zerofc
-val1	ldx txtptr
-	ldy txtptr+1
-	stx strng2
-	sty strng2+1
-	ldx index1
-	stx txtptr
-	lda index1		;load the low byte of index1
+val1	lda len1
 	clc
-	adc len1		;add len to index1 and put in strng2
-	sta strng2
-	lda index1+1	;load the high byte of index1
-	adc #0
-	sta strng2+1	;store result in high byte of strng2
-	ldx index1+1
-	stx txtptr+1
-	bcc val2
-	inx
-val2	stx strng2+1
-	lda (strng2)	;replace character after string with $00 (fake eol)
-	pha
+	adc #1
+	sta len2
+	jsr val_alloc
+	ldx txtptr
+	ldy txtptr+1
+	ldx #0
+val2	lda (txtptr),y
+	sta val_strptr
+	iny
+	dex
+	bne val2
 	lda #0
-	sta (strng2)
+	sta val_strptr
+	ldx val_strptr
+	stx txtptr
+	ldx val_strptr+1
+	stx txtptr+1
 	jsr chrgot
-	jsr finh		;go do evaluation
-	pla				;get pres'd character.
-	sta (strng2)	;restore zeroed-out character
+	jsr finh
 st2txt	ldx strng2	;restore text pointer
 	ldy strng2+1
 	stx txtptr
 	sty txtptr+1
 valrts	rts			;done!
+val_alloc	lda len2
+	jsr strspa
+	rts
 getnum	jsr frmadr
 combyt	jsr chkcom
 	jmp getbyt

--- a/basic/code17.s
+++ b/basic/code17.s
@@ -12,9 +12,7 @@ conint	jsr posint
 val	jsr len1        ;get length
 val_str	bne @1      ;return 0 if len=0
 	jmp zerofc
-@1:	cmp #254        ;check if string is =>255 chars (including null)
-	bne val_strlong ;yes, return 0
-	ldx txtptr      ;save current txtptr
+@1:	ldx txtptr      ;save current txtptr
 	ldy txtptr+1
 	phy
 	phx
@@ -25,6 +23,7 @@ val_str	bne @1      ;return 0 if len=0
 	phx
 	pha
 	inc
+	beq val_strlong
 	jsr strspa     ;allocate memory for string (this destroys index1, but we saved it to stack)
 	plx            ;restore saved string length
 	pla
@@ -49,17 +48,14 @@ val_str	bne @1      ;return 0 if len=0
 	ply
 	stx txtptr
 	sty txtptr+1
-	plx            ;restore saved index1
-	ply
-	stx index1
-	sty index1+1
 	rts            ;done!
 st2txt	ldx strng2 ;restore text pointer
 	ldy strng2+1
 	stx txtptr
 	sty txtptr+1
 valrts	rts        ;done!
-val_strlong	jmp zerofc
+val_strlong	ldx #errls
+	jmp error
 getnum	jsr frmadr
 combyt	jsr chkcom
 	jmp getbyt

--- a/basic/code17.s
+++ b/basic/code17.s
@@ -4,36 +4,45 @@ conint	jsr posint
 	bne gofuc
 	ldx faclo
 	jmp chrgot
-val	jsr len1
-val_str	bne @1
+
+; the "val" function takes a string and turns it into a number by interpreting
+; the ascii digits etc. Except for the problem that a terminator must be
+; supplied by replacing the character beyond the string, VAL is merely a call
+; to floating point input ("finh").
+val	jsr len1		;get length
+val_str	bne val1	;return 0 if len=0
 	jmp zerofc
-@1:	ldx txtptr
+val1	ldx txtptr
 	ldy txtptr+1
 	stx strng2
 	sty strng2+1
 	ldx index1
 	stx txtptr
+	lda index1		;load the low byte of index1
 	clc
-	adc index1
-	sta index2
+	adc len1		;add len to index1 and put in strng2
+	sta strng2
+	lda index1+1	;load the high byte of index1
+	adc #0
+	sta strng2+1	;store result in high byte of strng2
 	ldx index1+1
 	stx txtptr+1
 	bcc val2
 	inx
-val2	stx index2+1
-	lda (index2)
+val2	stx strng2+1
+	lda (strng2),y	;replace character after string with $00 (fake eol)
 	pha
 	lda #0
-	sta (index2)
+	sta (strng2),y
 	jsr chrgot
-	jsr finh
-	pla
-	sta (index2)
-st2txt	ldx strng2
+	jsr finh		;go do evaluation
+	pla				;get pres'd character.
+	sta (strng2),y	;restore zeroed-out character
+st2txt	ldx strng2	;restore text pointer
 	ldy strng2+1
 	stx txtptr
 	sty txtptr+1
-valrts	rts
+valrts	rts			;done!
 getnum	jsr frmadr
 combyt	jsr chkcom
 	jmp getbyt

--- a/cfg/x16.cfginc
+++ b/cfg/x16.cfginc
@@ -18,7 +18,7 @@ ZPDOS:    start = $0091, size = $000B; # DOS
 /*        start = $009C, size = $000B; # reserved for DOS or BASIC growth */
 ZPAUDIO:  start = $00A7, size = $0002; # AUDIO
 ZPMATH:   start = $00A9, size = $002B; # MATH
-ZPBASIC:  start = $00D4, size = $002B; # BASIC (last byte used: $FE)
+ZPBASIC:  start = $00D4, size = $002E; # BASIC (last byte used: $FE)
 
 /* $0200-$02FF: always-available variables and RAM code */
 KVAR:     start = $0200, size = $0095; # KERNAL

--- a/cfg/x16.cfginc
+++ b/cfg/x16.cfginc
@@ -18,7 +18,7 @@ ZPDOS:    start = $0091, size = $000B; # DOS
 /*        start = $009C, size = $000B; # reserved for DOS or BASIC growth */
 ZPAUDIO:  start = $00A7, size = $0002; # AUDIO
 ZPMATH:   start = $00A9, size = $002B; # MATH
-ZPBASIC:  start = $00D4, size = $002E; # BASIC (last byte used: $FE)
+ZPBASIC:  start = $00D4, size = $002B; # BASIC (last byte used: $FE)
 
 /* $0200-$02FF: always-available variables and RAM code */
 KVAR:     start = $0200, size = $0095; # KERNAL


### PR DESCRIPTION
The following modifications in `basic/code17.s` fixes the 1E39 bug (see #247) that we inherited from the C64.
![2024-08-31_23-46](https://github.com/user-attachments/assets/03e5ddad-268c-4f0f-8145-a8116f45d68d)
