### PR TITLE
[KERNAL] typematic preference apply fix, build relist fixes

### DIFF
--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -51,6 +51,8 @@ MODIFIER_SHIFT = 1
 
 .export defcb
 
+.import tpmcache, tpmflg
+
 ; screen driver
 .import screen_mode
 .import screen_set_charset
@@ -249,6 +251,12 @@ cint	jsr iokeys
 @l2
 	jsr kbd_config  ;set keyboard layout
 
+	jsr fetch_typematic_from_nvram
+	KVARS_START_TRASH_X_NZ
+	sta tpmcache
+	stz tpmflg
+	KVARS_END_TRASH_X_NZ
+
 	lda #$c
 	sta blnct
 	sta blnsw
@@ -336,10 +344,10 @@ loop3
 :
 
 	jsr fetch_typematic_from_nvram ; after toggle, new profile
-	bmi loop3b
-	tax
-	lda #6
-	jsr extapi
+	KVARS_START_TRASH_X_NZ
+	sta tpmcache
+	stz tpmflg
+	KVARS_END_TRASH_X_NZ
 
 	bra loop3b
 scrpnc

--- a/kernal/drivers/x16/ps2data.s
+++ b/kernal/drivers/x16/ps2data.s
@@ -20,7 +20,7 @@ PS2DATA_NEW_STYLE = $02
 LED_NUM_LOCK	= 2
 
 .import i2c_read_byte, i2c_read_first_byte, i2c_direct_read, i2c_read_next_byte, i2c_read_stop, i2c_write_byte
-.import tpmflg, ledstate
+.import tpmflg, tpmcache, ledstate
 
 .export ps2data_init, ps2data_fetch, ps2data_kbd, ps2data_kbd_count, ps2data_mouse, ps2data_mouse_count
 .export ps2data_keyboard_and_mouse, ps2data_keyboard_only, ps2data_raw
@@ -48,6 +48,8 @@ ps2data_init:
 
 	; Clear keyboard set typematic rate/delay flag
 	stz tpmflg
+	lda #$ab ; default (won't configure kbd because bit 7 is set)
+	sta tpmcache
 
 	; Set internal numlock state to defaults
 	lda #LED_NUM_LOCK

--- a/kernal/drivers/x16/ps2kbd.s
+++ b/kernal/drivers/x16/ps2kbd.s
@@ -32,9 +32,9 @@
 
 .export kbd_config, kbd_scan, receive_scancode_resume, keymap, ps2kbd_typematic
 .export kbd_leds
-.export tpmflg, ledstate
+.export tpmflg, tpmcache, ledstate
 
-.import extapi, fetch_typematic_from_nvram
+.import extapi
 
 I2C_ADDRESS = $42
 I2C_KBD_ADDRESS = $43
@@ -77,6 +77,8 @@ curkbd:	.res 1           ;    current keyboard layout index
 dk_shift:
 	.res 1
 dk_scan:
+	.res 1
+tpmcache:
 	.res 1
 
 
@@ -285,9 +287,8 @@ _kbd_scan:
 
 	pha
 	phx
-	jsr fetch_typematic_from_nvram
+	ldx tpmcache
 	bmi @2
-	tax
 	lda #6
 	jsr extapi
 @2:	plx

--- a/scripts/relist.py
+++ b/scripts/relist.py
@@ -38,8 +38,8 @@ class Module:
 # TODO: It's probably more efficient for scan map to return a map of all modules, not just the one we're interested during
 #       this iteration.
 def scan_map(map_filename: str, lst_filename:str, segment_map:Dict[str,Segment], module_map:Dict[str,Module]):
-    segment_matcher = re.compile("^([A-Z][A-Z0-9_]*) *([0-9A-F]{6})  ([0-9A-F]{6})  ([0-9A-F]{6})  ([0-9A-F]{5})$", re.IGNORECASE)
-    lst_matcher = re.compile("^    ([A-Z][A-Z0-9_]*) *Offs=([0-9A-F]{6})  Size=([0-9A-F]{6})  Align=([0-9A-F]{5})  Fill=([0-9A-F]{4})$", re.IGNORECASE)
+    segment_matcher = re.compile(r"^([A-Z][A-Z0-9_]*) *([0-9A-F]{6})  ([0-9A-F]{6})  ([0-9A-F]{6})  ([0-9A-F]{5})$", re.IGNORECASE)
+    lst_matcher = re.compile(r"^    ([A-Z][A-Z0-9_]*) *Offs=([0-9A-F]{6})  Size=([0-9A-F]{6})  Align=([0-9A-F]{5})  Fill=([0-9A-F]{4})$", re.IGNORECASE)
     obj_filename = f"{os.path.basename(os.path.splitext(lst_filename)[0])}.o:"
 
     # print(f"Looking for {os.path.basename(os.path.splitext(lst_filename)[0])}.o")
@@ -86,7 +86,7 @@ def scan_map(map_filename: str, lst_filename:str, segment_map:Dict[str,Segment],
         # print(f"Done reading {line_num} lines")
         return segment_map, module_map
 
-lst_matcher = re.compile("^([0-9A-F]{6})r \\d  (\w\w |   )(\w\w |   )(\w\w |   )(\w\w |   )\s*$")
+lst_matcher = re.compile(r"^([0-9A-F]{6})r \\d  (\w\w |   )(\w\w |   )(\w\w |   )(\w\w |   )\s*$")
 seg_matcher = re.compile(r'^\s*\.segment "([A-Z_][A-Z0-9_]*)"', re.IGNORECASE)
 spc_matcher = re.compile(r'^\s*\.(bss|code|data|rodata|zeropage)(\s|$)', re.IGNORECASE)
 

--- a/scripts/trace_info.py
+++ b/scripts/trace_info.py
@@ -19,15 +19,15 @@ bank = None # Holds the bank we're creating listings and symbols for
 cur_bank = 0 # Holds the bank of the line that is currently parsed
 
 # Regex
-segmentParser = re.compile("^[\s]*.segment[\s]+[\"\'][\w]+[\"\']", re.IGNORECASE)
-memoryDefintionParser = re.compile("memory[\s]*\{[^\}]*\}", re.IGNORECASE)
-segmentDefinitionParser = re.compile("segments[\s]*\{[^\}]*\}", re.IGNORECASE)
-configLineParser = re.compile("[\w]+[\s]*:[^;]*;", re.IGNORECASE)
-hexnumParser = re.compile("^\$[0-9a-f]+$", re.IGNORECASE)
-hexnumParser2 = re.compile("^0x[0-9a-f]+$", re.IGNORECASE)
-decnumParser = re.compile("^[0-9]+$", re.IGNORECASE)
-labelParser = re.compile("^[\s]*[a-z]+[a-z0-9]*\:", re.IGNORECASE)
-procParser = re.compile("^[\s]*.proc[\s]+", re.IGNORECASE)
+segmentParser = re.compile(r"^[\s]*.segment[\s]+[\"\'][\w]+[\"\']", re.IGNORECASE)
+memoryDefintionParser = re.compile(r"memory[\s]*\{[^\}]*\}", re.IGNORECASE)
+segmentDefinitionParser = re.compile(r"segments[\s]*\{[^\}]*\}", re.IGNORECASE)
+configLineParser = re.compile(r"[\w]+[\s]*:[^;]*;", re.IGNORECASE)
+hexnumParser = re.compile(r"^\$[0-9a-f]+$", re.IGNORECASE)
+hexnumParser2 = re.compile(r"^0x[0-9a-f]+$", re.IGNORECASE)
+decnumParser = re.compile(r"^[0-9]+$", re.IGNORECASE)
+labelParser = re.compile(r"^[\s]*[a-z]+[a-z0-9]*\:", re.IGNORECASE)
+procParser = re.compile(r"^[\s]*.proc[\s]+", re.IGNORECASE)
 
 # Converts string to number
 # Accepted formats: decimal numbers, hexadecimal numbers (0xn or $n)


### PR DESCRIPTION
The code avoids calling the handler-unsafe routine `fetch_typematic_from_nvram` inside the ps2 fetch handler.

This also includes fixes for Python regexes in the relist build scripts.  String literals without the `r` prefix (raw string literal) could have the possibility of the escapes being processed before being passed to the `re` module.