### PR TITLE
Change SNES timings to specs

### DIFF
--- a/kernal/drivers/x16/joystick.s
+++ b/kernal/drivers/x16/joystick.s
@@ -142,7 +142,7 @@ joy_detect:
 
 	; Store joytstick connection flags
 	sta joycon
-:
+	
 	KVARS_END_TRASH_A_NZ
 	rts
 

--- a/kernal/drivers/x16/joystick.s
+++ b/kernal/drivers/x16/joystick.s
@@ -142,7 +142,7 @@ joy_detect:
 
 	; Store joytstick connection flags
 	sta joycon
-	
+
 	KVARS_END_TRASH_A_NZ
 	rts
 
@@ -233,7 +233,6 @@ joystick_get:
 	ldy #0
 :	lda joy4
 	ldx joy4+1
-	ldy joy4+2
 
 @5:	KVARS_END
 	rts

--- a/kernal/drivers/x16/joystick.s
+++ b/kernal/drivers/x16/joystick.s
@@ -72,7 +72,15 @@ joystick_scan:
 	sta nes_data
 	jsr wait_6us
 	jsr wait_6us
-	stz nes_data
+	pha
+	pla
+	pha
+	pla
+	stx nes_data
+
+	; Wait 6 us after latch falling edge
+	jsr wait_6us
+	nop
 	
 	; Read SNES controller bits 0..7
 	ldy #8
@@ -92,6 +100,9 @@ l1:	; Drive NES clock low for approx 6 us and read data (SNES controller doesn't
 	rol joy3   ; Roll C into joy3
 	rol        ; Roll bit 4 into C
 	rol joy4   ; Roll C into joy4
+	nop
+	nop
+	nop
 
 	dey
 	bne l1
@@ -114,6 +125,9 @@ l2:	; Drive SNES clock low for approx 6 us and read data (SNES controller doesn'
 	rol joy3+1 ; Roll C into joy3
 	rol        ; Roll bit 4 into C
 	rol joy4+1 ; Roll C into joy4
+	nop
+	nop
+	nop
 
 	dey
 	bne l2
@@ -162,12 +176,10 @@ wait_6us:
 	pla
 	pha
 	pla
-	pha
-	pla
+	nop
 wait_3us:
 	pha
 	pla
-	nop
 	nop
 	nop
 	rts


### PR DESCRIPTION
This is an attempt to follow SNES timing specs more closely.

In the current master branch, scanning the SNES controllers takes 1,473 clock cycles = 184 us.

This PR slows down the SNES controller latch and clock to about 12 us, according to specs. This increases the time needed to scan the controllers.

The SNES controller sends 16 bits of data. The current master branch reads another 8 bits, a total of 24 bits, where the last 8 bits are only used to check if a controller is present. This PR changes the controller detection by reading only one extra bit, reducing the duration of the scan.

After these two changes, scanning the SNES controllers takes 1,838 clock cycles = 230 us, i.e. 46 us more than the current master branch implementation.

It might be enough to get more SNES controller clones to work. If so, we need to decide if that is worth the extra 46 us.