### PR TITLE
extapi: Add `memory_decompress_from_func`

### DIFF
--- a/kernal/x16/extapi.s
+++ b/kernal/x16/extapi.s
@@ -12,6 +12,7 @@
 .import mouse_set_position
 .import scnsiz
 .import kbd_leds
+.import memory_decompress_internal
 
 .export extapi
 
@@ -43,17 +44,18 @@ secrts:
 
 apitbl:
 	.word secrts-1 ; slot 0 is reserved
-	.word clear_status-1          ; API 1
-	.word extapi_getlfs-1         ; API 2
-	.word mouse_sprite_offset-1   ; API 3
-	.word joystick_ps2_keycodes-1 ; API 4
-	.word iso_cursor_char-1       ; API 5
-	.word ps2kbd_typematic-1      ; API 6
-	.word pfkey-1                 ; API 7
-	.word ps2data_fetch-1         ; API 8
-	.word ps2data_raw-1           ; API 9
-	.word cursor_blink-1          ; API 10
-	.word led_update-1            ; API 11
-	.word mouse_set_position-1    ; API 12
-	.word scnsiz-1                ; API 13
-	.word kbd_leds-1              ; API 14
+	.word clear_status-1               ; API 1
+	.word extapi_getlfs-1              ; API 2
+	.word mouse_sprite_offset-1        ; API 3
+	.word joystick_ps2_keycodes-1      ; API 4
+	.word iso_cursor_char-1            ; API 5
+	.word ps2kbd_typematic-1           ; API 6
+	.word pfkey-1                      ; API 7
+	.word ps2data_fetch-1              ; API 8
+	.word ps2data_raw-1                ; API 9
+	.word cursor_blink-1               ; API 10
+	.word led_update-1                 ; API 11
+	.word mouse_set_position-1         ; API 12
+	.word scnsiz-1                     ; API 13
+	.word kbd_leds-1                   ; API 14
+	.word memory_decompress_internal-1 ; API 15


### PR DESCRIPTION
This exposes a functionality that already was available to the internal kernal code. This function works in a similar manner to `memory_decompress`, but instead of taking an address of compressed data in `r0`, it takes, in `r4`, an address of a function that *streams* LZSA2 data byte by byte each call. 

### Rationale:
This was already available in the kernal and such a function might be useful in many scenarios, such as:
- decompressing data incoming from a serial connection on the fly
- decompressing stuff stored on a cartridge ([usage attested in the kernal itself](https://github.com/X16Community/x16-rom/blob/8e9117eb864a6ffc66ced72f5bb168ee0b1cbf76/kernal/drivers/x16/ps2kbd.s#L200-L214))
- decompressing data from the banked ram (and automatically handle the bank switching, obviously)

I'll write the proper documentation of the function once it gets greenlit.