### PR TITLE
Fix crc function

### DIFF
--- a/kernal/memory.s
+++ b/kernal/memory.s
@@ -225,12 +225,16 @@ memory_crc:
 	sta r2L
 	sta r2H
 
+; CRC at address 9Fxx uses fixed address
 	lda r0H
 	cmp #IO_PAGE
 	beq io_crc
+
 	pha
 	lda r1H
 	beq @2
+
+; accumulate a whole number of 256 bytes chunks
 	ldy #0
 @1:	lda (r0),y
 	jsr crc16_f
@@ -239,6 +243,8 @@ memory_crc:
 	inc r0H
 	dec r1H
 	bne @1
+
+; accumulate remainder
 @2:	ldy r1L
 	beq @4
 @3:	dey

--- a/kernal/memory.s
+++ b/kernal/memory.s
@@ -230,12 +230,12 @@ memory_crc:
 	cmp #IO_PAGE
 	beq io_crc
 
+	ldy #0
 	pha
 	lda r1H
 	beq @2
 
 ; accumulate a whole number of 256 bytes chunks
-	ldy #0
 @1:	lda (r0),y
 	jsr crc16_f
 	iny
@@ -245,12 +245,13 @@ memory_crc:
 	bne @1
 
 ; accumulate remainder
-@2:	ldy r1L
+@2:	lda r1L
 	beq @4
-@3:	dey
-	lda (r0),y
+	; y starts at 0
+@3:	lda (r0),y
 	jsr crc16_f
-	cpy #0
+	iny
+	dec r1L
 	bne @3
 @4:	PopB r0H
 	rts


### PR DESCRIPTION
The old implementation first accumulated a whole number of 256 byte chunks.
Then, it did the remaining bytes.
The old implementation was incorrectly using Y as a downcounter AND an offset using the "lda (r0),y" instruction for the remainder part. Causing remainder bytes to be accumulated in the wrong order.
This pull request fixes the order of the remainder bytes, so that they get accumulated in the same order as the rest of the file.
For the record: r1L (number of bytes) gets trashed, since r1H also gets trashed. Although r0 (address) is preserved.

Fixes #381 

This change causes the function to generate the same results as "CRC-16/IBM-3740", ref this online calculator: https://www.crccalc.com/?crc=01%2002%2003%2004&method=CRC-16/IBM-3740&datatype=hex&outtype=hex 