### PR TITLE
[META] add license and help notes to jsrfar.inc

### DIFF
--- a/inc/jsrfar.inc
+++ b/inc/jsrfar.inc
@@ -1,5 +1,59 @@
 ; LONG CALL  utility
+
+; Copyright 2019-2025 Commander Computers LLC, Michael Steil, and others.
 ;
+; Redistribution and use in source and binary forms, with or without
+; modification, are permitted provided that the following conditions are met:
+;
+; 1. Redistributions of source code must retain the above copyright notice,
+; this list of conditions and the following disclaimer.
+;
+; 2. Redistributions in binary form must reproduce the above copyright notice,
+; this list of conditions and the following disclaimer in the documentation
+; and/or other materials provided with the distribution.
+;
+; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+; POSSIBILITY OF SUCH DAMAGE.
+
+
+; This include file, in combination with the constants inside "banks.inc"
+; implement the ROM portion of the jsrfar call.  It is the meat of the jsrfar
+; code inside the KERNAL bank of x16-rom. It is also separately ".include"ed in
+; other x16-rom banks to facilitate inter-bank calls.
+
+; This file or a modified version may be used in other projects, whether free
+; or proprietary, with or without source available, such as cartridge-based
+; applications and games, so long as the above copyright notice remains in
+; distributed source code and that binary distributions include the above
+; copyright notice somewhere in the included documentation.
+
+; To use in your projects, include this file after your custom jsrfar label.
+; For instance:
+;
+; myjsrfar:
+;     .include "jsrfar.inc"
+;
+; myfunc:
+;   lda #0
+;   jsr myjsrfar
+;   .word $FFD5 ; LOAD
+;   .byte 0
+;   jsr myjsrfar
+;   .word $FFB7 ; READST
+;   .byte 0
+;
+
+; Below is the original comment for jsrfar usage
+
 ; jsr jsrfar
 ; .word address
 ; .byte bank


### PR DESCRIPTION
The license and method of external usage of jsrfar.inc was not clear.  Updating with license text and example.