### PR TITLE
fix: correct value of BASIC π constant

### DIFF
--- a/basic/code9.s
+++ b/basic/code9.s
@@ -196,7 +196,7 @@ pival	.byt $82
 	.byt $49
 	.byt $0f
 	.byt $da
-	.byt $a1
+	.byt $a2
 qdot	cmp #'.'
 	beq eval1
 	cmp #minutk


### PR DESCRIPTION
Fixes #385 