### PR TITLE
[DOS/FAT32] Use carry for instead of `krn_ptr1` to indicate writes to the same address

### DIFF
--- a/dos/functions.s
+++ b/dos/functions.s
@@ -33,7 +33,7 @@
 .import create_unix_path_only_dir, create_unix_path_only_name, append_unix_path_only_name
 
 .import buffer
-.importzp krn_ptr1, bank_save
+.importzp bank_save
 
 .import context_for_channel
 
@@ -631,9 +631,7 @@ copy_do:
 	stz fat32_size
 	lda #1
 	sta fat32_size + 1
-	lda krn_ptr1			; krn_ptr1 bit 7 = 0 => disable that fat32_read stores to all data to same destination address
-	and #%01111111
-	sta krn_ptr1
+	clc ; disable that fat32_read stores to all data to same destination address
 	fat32_call fat32_read
 	bcs :+
 	lda fat32_errno
@@ -651,6 +649,7 @@ copy_do:
 	sta fat32_ptr
 	lda #>unix_path
 	sta fat32_ptr + 1
+	clc
 	fat32_call fat32_write
 	bcc @error_errno
 

--- a/fat32/README.md
+++ b/fat32/README.md
@@ -55,8 +55,8 @@ Most API calls require a context to be allocated and set. Contexts are associate
 * `fat32_open`: Open existing file. Pass path in `fat32_ptr`.
 * `fat32_create`: Create new file. Pass path in `fat32_ptr`, C=1 to overwrite.
 * `fat32_close`: Close open file. The timestamp will be updated from `fat32_time_year` etc.
-* `fat32_read`: Read from file. Pass pointer in `fat32_ptr`, size in `fat32_size`. Returns bytes read in `fat32_size`.
-* `fat32_write`: Write to file. Pass pointer in `fat32_ptr`, size in `fat32_size`.
+* `fat32_read`: Read from file. Pass pointer in `fat32_ptr`, size in `fat32_size`. Returns bytes read in `fat32_size`. C=1 to not increment the buffer pointer (useful for reads into the IO range).
+* `fat32_write`: Write to file. Pass pointer in `fat32_ptr`, size in `fat32_size`. C=1 to not increment the buffer pointer (useful for reads into the IO range).
 * `fat32_read_byte`: Read a byte from open file. Returns byte in A.
 * `fat32_write_byte`: Write a byte to open file. Pass byte in A.
 * `fat32_get_offset`: Get current offset in file. Returns value in `fat32_size`.

--- a/fat32/README.md
+++ b/fat32/README.md
@@ -55,8 +55,8 @@ Most API calls require a context to be allocated and set. Contexts are associate
 * `fat32_open`: Open existing file. Pass path in `fat32_ptr`.
 * `fat32_create`: Create new file. Pass path in `fat32_ptr`, C=1 to overwrite.
 * `fat32_close`: Close open file. The timestamp will be updated from `fat32_time_year` etc.
-* `fat32_read`: Read from file. Pass pointer in `fat32_ptr`, size in `fat32_size`. Returns bytes read in `fat32_size`. C=1 to not increment the buffer pointer (useful for reads into the IO range).
-* `fat32_write`: Write to file. Pass pointer in `fat32_ptr`, size in `fat32_size`. C=1 to not increment the buffer pointer (useful for reads into the IO range).
+* `fat32_read`: Read from file. Pass pointer in `fat32_ptr`, size in `fat32_size`. Returns bytes read in `fat32_size`. C=1 to not increment the buffer pointer (useful for reads that are written into the IO range).
+* `fat32_write`: Write to file. Pass pointer in `fat32_ptr`, size in `fat32_size`. C=1 to not increment the buffer pointer (useful for writes that are read from the IO range).
 * `fat32_read_byte`: Read a byte from open file. Returns byte in A.
 * `fat32_write_byte`: Write a byte to open file. Pass byte in A.
 * `fat32_get_offset`: Get current offset in file. Returns value in `fat32_size`.

--- a/fat32/fat32.s
+++ b/fat32/fat32.s
@@ -3043,7 +3043,7 @@ fat32_read_byte:
 ;
 ; fat32_ptr          : pointer to store read data
 ; fat32_size (16-bit): size of data to read
-; krn_ptr1           : if MSB set, copy all bytes to same destination address.
+; c=1                : copy all bytes to same destination address.
 ;
 ; On return fat32_size reflects the number of bytes actually read
 ;
@@ -3051,6 +3051,10 @@ fat32_read_byte:
 ;-----------------------------------------------------------------------------
 fat32_read:
 	stz fat32_errno
+
+	; Store carry flag
+	ror krn_ptr1
+
 	set16 fat32_ptr2, fat32_size
 
 fat32_read_again:
@@ -3391,12 +3395,15 @@ fat32_write_byte:
 ;
 ; fat32_ptr          : pointer to data to write
 ; fat32_size (16-bit): size of data to write
-; krn_ptr1           : if MSb set, copy all bytes from same source address.
+; c=1                : copy all bytes from same source address.
 ;
 ; * c=0: failure; sets errno
 ;-----------------------------------------------------------------------------
 fat32_write:
 	stz fat32_errno
+
+	; Store carry flag
+	ror krn_ptr1
 
 	; Calculate number of bytes remaining in buffer
 	sec


### PR DESCRIPTION
`fat32_read` and `fat32_write` currently use `krn_ptr1` to determine whether to increment
the buffer pointer or not; the latter is used for reads from / writes to an IO address.
As this is a DOS variable with a variable address that is unrelated to the other named
FAT32 variables, this commit changes this to use the carry flag instead; calling the function
with carry set prevents address incrementing.