### PR TITLE
Do not add extra LFN entries if file name length is a multiple of 13

### DIFF
--- a/fat32/fat32.s
+++ b/fat32/fat32.s
@@ -2125,6 +2125,10 @@ create_lfn:
 	jsr encode_lfn_chars
 	bcc @name_done
 
+	; Is the next character zero-termination? If yes, stop here (length 13/26/39/...)
+	lda (fat32_ptr), y
+	beq @name_done
+
 	add16_val fat32_lfn_bufptr, fat32_lfn_bufptr, 32
 
 	inc lfn_index


### PR DESCRIPTION
Ref Wikipedia, and my own testing, there should not be added new LFN entries with only a zero terminator. Windows 10 struggles dealing with the files with one extra LFN entry with only zero terminator.