### PR TITLE
#407 - Fixes to handle new ca65 target selection

### DIFF
--- a/audio/playstring.s
+++ b/audio/playstring.s
@@ -3,7 +3,7 @@
 ; This file is for code dealing with the blocking note playback via
 ; string
 
-.setcpu "65c02"
+.setcpu "w65c02"
 
 .include "io.inc" ; for YM2151 addresses
 .include "kernal.inc" ; for checking the STOP key

--- a/util/control.s
+++ b/util/control.s
@@ -6,7 +6,7 @@
 ;by MooingLemur 2023
 ;x16e546@oomox.com
 
-.pc02
+.setcpu "w65c02"
 
 .macpack cbm
 


### PR DESCRIPTION
Fixes https://github.com/X16Community/x16-rom/issues/407
Properly sets the CPU target to support the WAI instruction.