### PR TITLE
Fix old bug in Kernal open function

### DIFF
--- a/kernal/cbm/channel/openchannel.s
+++ b/kernal/cbm/channel/openchannel.s
@@ -58,7 +58,11 @@ jx320	sta dfltn       ;all input come from here
 jx330	tax             ;device # for dflto
 	jsr talk        ;tell him to talk
 ;
-	lda sa          ;a second?
+	bit status	;anybody home?
+	bpl jx331
+	jmp error5	;... branch if no response
+;
+jx331	lda sa          ;a second?
 	bpl jx340       ;yes...send it
 	jsr tkatn       ;no...let go
 	jmp jx350


### PR DESCRIPTION
According to the C64 Programmer's reference guide, OPEN should, amongst other, return error code 5 (Device not present). 

The Kernal aborts without checking if the device is present if the file name is zero length. No error codes are raised.

Opening a zero length file name with secondary address 15 is a practical way of reading the disk status. If you do that on a device not present, the Kernal currently hangs, and the computer must be reset.

This fix removes the first check for zero file name length. The Kernal continues to send LISTEN + OPEN CHANNEL commands to the selected device. If not present, OPEN will fail with error code 5 as advertised in the PRG.

There is another check for zero file name length just before the Kernal is to send the file name to the device.

I haven't so far been able to find any unexpected behavior after applying this fix.