### PR TITLE
Critical VIA or memory handler

### DIFF
--- a/diag/macros.inc
+++ b/diag/macros.inc
@@ -209,3 +209,8 @@ check:	cmp	(mem_ptr),y
 .endscope
 .endmacro
 .endif
+
+.macro POST code
+	lda	#code
+	sta	POST_IO_PORT
+.endmacro


### PR DESCRIPTION
This adds the capability to the diagnostic ROM bank to detect critical failures at boot and bring up VERA (if possible) and display an error code.

Faults detected:
* Bad zero page memory (HW FAULT B0)
* Bad stack memory (HW FAULT B1)
* Bad/missing VIA (HW FAULT A0)

If one of these critical faults are detected, an attempt will be made to bring up VERA in VGA mode and display the fault number. The VERA initialization code in this critical scenario will bring up VERA without using any memory, zero page, or the stack.

Also adds POST codes, written to $9FFF for a future hardware device capable of displaying fault information to the user even if VERA will not come up.