### PR TITLE
[BASIC] correct buflen should be 81, not 89.

### DIFF
--- a/basic/declare.s
+++ b/basic/declare.s
@@ -1,6 +1,6 @@
 romloc	=$c000          ;x16 basic rom
 lofbuf	=$ff            ;$FF the low fac buffer. copyable
-buflen	=80             ;vic-20 and C64 buffer was 89, but our memory map isn't large enough
+buflen	=81             ;vic-20 and C64 buffer was 89, but our memory map isn't large enough
 bufpag	=2
 buf	=512
 .assert buf = 512, error, "cc65 depends on BASIC_BUF = $200, change with caution"


### PR DESCRIPTION
This bug is only ever hit on modes in which the row lengths don't divide 80 evenly.  Modes 7 and above qualify, so if a user tried to enter a line longer than 80 characters, it would corrupt KERNAL RAM just past the buffer.