### PR TITLE
[KERNAL] fix errant logic in cursor blink color swap

### DIFF
--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -62,6 +62,7 @@ MODIFIER_SHIFT = 1
 .import screen_set_char
 .import screen_set_char_color
 .import screen_get_char_color
+.import screen_get_color_cont
 .import screen_set_position
 .import screen_get_position
 .import screen_copy_line
@@ -1303,13 +1304,13 @@ cursor_blink:
 	lda #20         ;reset blink counter
 	sta blnct
 	ldy pntr        ;cursor position
+	ldx gdcol
+	jsr screen_get_char
 	lsr blnon       ;carry set if original char
-	php
-	jsr screen_get_char_color
-	inc blnon       ;set to 1
-	plp
 	bcs @1          ;branch if not needed
+	inc blnon       ;set to 1
 	sta gdbln       ;save original char
+	jsr screen_get_color_cont
 	stx gdcol       ;save original color
 	ldx color       ;blink in this color
 @1	bit mode

--- a/kernal/drivers/x16/screen.s
+++ b/kernal/drivers/x16/screen.s
@@ -17,6 +17,7 @@
 .export screen_set_char
 .export screen_set_char_color
 .export screen_get_char_color
+.export screen_get_color_cont
 .export screen_set_position
 .export screen_get_position
 .export screen_copy_line
@@ -516,6 +517,7 @@ screen_set_char_color:
 ;---------------------------------------------------------------
 screen_get_char_color:
 	jsr screen_get_char
+screen_get_color_cont:
 	ldx VERA_DATA0     ;get color
 	rts
 


### PR DESCRIPTION
This update better follows the original C64 logic.

<img width="374" height="422" alt="image" src="https://github.com/user-attachments/assets/17241d58-a5df-4902-b039-5a19c527ad4d" />

Closes #416 