### PR TITLE
Making kbdbuf_peek atomic

### DIFF
--- a/kernal/kbdbuf.s
+++ b/kernal/kbdbuf.s
@@ -34,11 +34,12 @@ kbdbuf_clear:
 
 kbdbuf_peek:
 	KVARS_START
-	php
+	php ; Disable IRQ
 	sei
-	lda keyd
-	ldx ndx
-	plp
+	lda keyd ; Get key
+	ldx ndx ; Get buffer count
+	plp ; Restore IRQ
+	cpx #0 ; If ndx=0 then Z=1 else Z=0
 	KVARS_END
 	rts
 


### PR DESCRIPTION
The intention of this is to prevent that kbfbuf_peek is interrupted, as it could cause the function not to return the correct result.