### PR TITLE
[BUILD] Fail early if findsymbols fails

### DIFF
--- a/findsymbols
+++ b/findsymbols
@@ -15,12 +15,12 @@ usage () {
 
 #Validate input
 if [ $# -lt 2 ]; then
-	usage
+	usage >&2
 fi
 
 if [[ ! -f $1 ]]; then
-	echo "File not found"
-	usage
+	echo >&2 "File not found: $1"
+	usage >&2
 fi
 
 #Get symbol names from command line parameters


### PR DESCRIPTION
If `findsymbols` fails, it prints a helpful usage message to standard output:

> ```plain
> Usage: findsymbols file [-p prefix] symbol ...
>   file:
>     Symbol file created with the -Ln option in ld65
>   -p prefix:
>     A prefix added to all returned symbol names
>   symbol:
>     Name of one or more symbols
> ```

Unfortunately, the Makefile ignores the exit status of `findsymbols`. It then misinterprets the whole help text as legitimate output and rolls it all into the linker command line.

Because the help text happens to contain the word `-Ln` and there’s another `-Ln` in the command line already, the linker treats this duplication as an error and bails with the error message from issue #363:

> ld65: Error: Cannot use -Ln twice

This PR is to improve the error message and fix the leaky help text.

It redirects the help text to stderr (so the help text is no longer misinterpreted as legitimate output) and adds an exit status guard (so the build fails early with a more useful error message.)

See my commit message for more details.

Note that this PR does **not** fix the root cause of #363, which I think should be a separate PR.

@mooinglemur Review would be appreciated.
