### PR TITLE
Disable interrupts before jumping to diagnostics rom

### DIFF
--- a/util/menu.s
+++ b/util/menu.s
@@ -321,6 +321,7 @@ do_diag:
 	jmp show_menu
 @enter:	cmp #13
 	bne @getchoice
+	sei
 	jsr ujsrfar
 	.word $C000
 	.byte BANK_DIAG


### PR DESCRIPTION
Make it possible to start diagnostics rom from menu. With reference to report in "x16-general" today.

This ensures that vblank interrupt does not crash the machine when ISR is overwritten by memory test.