### PR TITLE
Always disable interrupts when starting diagnostics rom via jump table

### DIFF
--- a/diag/diag.s
+++ b/diag/diag.s
@@ -161,6 +161,7 @@ fail_safe_okay:
 	beq diag_start  ; poweron has been done with a long-press
 	jmp continue_original
 diag_start:
+	sei             ; Disable interrupts when starting via JMPTBL
 	jmp basemem_test
 basemem_ret:
 	ldx #$FF        ; Set stack pointer

--- a/util/menu.s
+++ b/util/menu.s
@@ -321,7 +321,6 @@ do_diag:
 	jmp show_menu
 @enter:	cmp #13
 	bne @getchoice
-	sei
 	jsr ujsrfar
 	.word $C000
 	.byte BANK_DIAG


### PR DESCRIPTION
The diag rom can be started in two ways:
- Long power-on press
- Jumping to $C000 in rom bank 7

Before #424 , both these ways of starting the diagnostics tool would disable interrupts.

#424 moved the SEI instruction, to be performed earlier when doing a long power-on start. However, this also caused that start via the jump table did not perform SEI.

This PR reintroduces the SEI removed in 424, while keeping the additional SEI that is done early, which should be a proper fix of this introduced bug.

Also reverts a redundant fix done in #449 .

This also makes it possible to start the diag rom using

```
BANK 7,7
SYS $C000
```