### PR TITLE
fix: adjust findsymbols definition to work in BSD make(1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ GIT_SIGNATURE=$(BUILD_DIR)/../signature.bin
 # Wrapper for findsymbols that escapes the output and guards against non-zero exit codes
 define findsymbols
 $(strip \
-	$(subst $,\$,$(shell ${BUILD_DIR}/../../findsymbols $(1) $(2))) \
+	$(shell ${BUILD_DIR}/../../findsymbols $(1) $(2)) \
 	$(if \
 		$(filter 0,$(firstword $(.SHELLSTATUS) 0)),, \
 		$(error findsymbols failed with exit code $(.SHELLSTATUS)) \

--- a/findsymbols
+++ b/findsymbols
@@ -56,7 +56,7 @@ BEGIN {
 {
 	for (s in symbols) {
 		if (symbols[s] == substr($3,2)) {
-			output[symbols[s]] = "$" substr($2,3)
+			output[symbols[s]] = "\\$" substr($2,3)
 		}
 	}
 }


### PR DESCRIPTION
The macro added in 8efde2d to wrap `findsymbols` and abort on failure incuded GNU make(1)-specific features (`$(subst)`), breaking the build on platforms using BSD make (like macOS). This removes the `$(subst)` call in the `findsymbols` macro definition in favor of having the `findsymbols` script itself output a backslash in front of the dollar signs in its hex literals. 

Fixes #448.