### PR TITLE
Fix for the No channel DOS error

### DIFF
--- a/dos/file.s
+++ b/dos/file.s
@@ -87,6 +87,7 @@ file_open:
 	bcs @alloc_ok
 
 	jsr convert_errno_status
+	jsr set_status
 	sec
 	rts
 

--- a/fat32/regs.inc
+++ b/fat32/regs.inc
@@ -26,7 +26,7 @@ mtime_seconds .byte
 
 ; Maximum number of open files
 ; Optionally, fat32_alloc_context / fat32_free_context can be used to manage contexts
-FAT32_CONTEXTS = 4
+FAT32_CONTEXTS = 8
 
 ; Maximum number of partitions
 FAT32_VOLUMES = 4


### PR DESCRIPTION
The Kernal's SD card interface is limited to opening four files at the same time.

If more than four files are opened, the NO CHANNEL error should be raised, which doesn't happen at the moment.

Most disk errors are not raised immediately upon the OPEN command, but rather when trying to access the file later on. FILE NOT FOUND is one example of that. I'm not sure how, for instance, the 1541 worked, but I assume it had to raise the NO CHANNEL error after the OPEN command, as it couldn't connect the file you tried to open to any resources.

For reference, the 1541 user manual described the error as follows:

"70: NO CHANNEL (available). The requested channel is not available, or all channels are in use. A maximum of five sequential files may be opened at one time to the DOS. Direct access channels may have six opened files."

This code has not yet been fully tested, and is therefore marked as draft.